### PR TITLE
feat: Add uno-platform-studio plugin, agent skills, and marketplaces

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "uno-platform",
+  "interface": {
+    "displayName": "Uno Platform"
+  },
+  "plugins": [
+    {
+      "name": "uno-platform-studio",
+      "source": {
+        "source": "local",
+        "path": "./plugins/uno-platform-studio"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Development"
+    }
+  ]
+}

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -11,8 +11,7 @@
         "path": "./plugins/uno-platform-studio"
       },
       "policy": {
-        "installation": "AVAILABLE",
-        "authentication": "ON_INSTALL"
+        "installation": "AVAILABLE"
       },
       "category": "Development"
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "version": "1.0.0",
-    "description": "Uno Platform skills for AI coding agents — cross-platform .NET app authoring with WinUI/Uno XAML, MVUX, Material Design, navigation, and more.",
+    "description": "Uno Platform skills for AI coding agents, cross-platform .NET app authoring with WinUI/Uno XAML, MVUX, Material Design, navigation, and more.",
     "homepage": "https://github.com/unoplatform/studio",
     "license": "Apache-2.0"
   },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,8 +8,8 @@
   "metadata": {
     "version": "1.0.0",
     "description": "Uno Platform skills for AI coding agents, cross-platform .NET app authoring with WinUI/Uno XAML, MVUX, Material Design, navigation, and more.",
-    "homepage": "https://github.com/unoplatform/studio",
-    "license": "Apache-2.0"
+    "homepage": "	https://aka.platform.uno/studio-feedback-repository",
+    "license": "https://aka.platform.uno/hot-design-terms-of-use"
   },
   "plugins": [
     {
@@ -17,7 +17,7 @@
       "description": "Skills covering MVUX, navigation, toolkit, themes (Material, Simple, shared semantic), and testing workflows for Uno Platform. The Uno documentation MCP is provided by the Uno tooling, not bundled in the plugin.",
       "source": "./plugins/uno-platform-studio",
       "version": "1.0.0",
-      "license": "Apache-2.0"
+      "license": "https://aka.platform.uno/hot-design-terms-of-use"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "metadata": {
     "version": "1.0.0",
     "description": "Uno Platform skills for AI coding agents, cross-platform .NET app authoring with WinUI/Uno XAML, MVUX, Material Design, navigation, and more.",
-    "homepage": "	https://aka.platform.uno/studio-feedback-repository",
+    "homepage": "https://aka.platform.uno/studio-feedback-repository",
     "license": "https://aka.platform.uno/hot-design-terms-of-use"
   },
   "plugins": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,16 +8,14 @@
   "metadata": {
     "version": "1.0.0",
     "description": "Uno Platform skills for AI coding agents, cross-platform .NET app authoring with WinUI/Uno XAML, MVUX, Material Design, navigation, and more.",
-    "homepage": "https://aka.platform.uno/studio-feedback-repository",
-    "license": "https://aka.platform.uno/hot-design-terms-of-use"
+    "homepage": "https://platform.uno/studio/"
   },
   "plugins": [
     {
       "name": "uno-platform-studio",
       "description": "Skills covering MVUX, navigation, toolkit, themes (Material, Simple, shared semantic), and testing workflows for Uno Platform. The Uno documentation MCP is provided by the Uno tooling, not bundled in the plugin.",
       "source": "./plugins/uno-platform-studio",
-      "version": "1.0.0",
-      "license": "https://aka.platform.uno/hot-design-terms-of-use"
+      "version": "1.0.0"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
   "plugins": [
     {
       "name": "uno-platform-studio",
-      "description": "Skills covering MVUX, navigation, toolkit, themes (Material, Simple, shared semantic), and testing workflows for Uno Platform. The Uno documentation MCP is provided by the Uno tooling (uno.devserver), not bundled in the plugin.",
+      "description": "Skills covering MVUX, navigation, toolkit, themes (Material, Simple, shared semantic), and testing workflows for Uno Platform. The Uno documentation MCP is provided by the Uno tooling, not bundled in the plugin.",
       "source": "./plugins/uno-platform-studio",
       "version": "1.0.0",
       "license": "Apache-2.0"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,23 @@
+{
+  "name": "uno-platform",
+  "owner": {
+    "name": "Uno Platform",
+    "url": "https://platform.uno",
+    "email": "info@platform.uno"
+  },
+  "metadata": {
+    "version": "1.0.0",
+    "description": "Uno Platform skills for AI coding agents — cross-platform .NET app authoring with WinUI/Uno XAML, MVUX, Material Design, navigation, and more.",
+    "homepage": "https://github.com/unoplatform/studio",
+    "license": "Apache-2.0"
+  },
+  "plugins": [
+    {
+      "name": "uno-platform-studio",
+      "description": "Skills covering MVUX, navigation, toolkit, themes (Material, Simple, shared semantic), and testing workflows for Uno Platform. The Uno documentation MCP is provided by the Uno tooling (uno.devserver), not bundled in the plugin.",
+      "source": "./plugins/uno-platform-studio",
+      "version": "1.0.0",
+      "license": "Apache-2.0"
+    }
+  ]
+}

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -8,16 +8,14 @@
   "metadata": {
     "version": "1.0.0",
     "description": "Uno Platform skills for AI coding agents, cross-platform .NET app authoring with WinUI/Uno XAML, MVUX, Material Design, navigation, and more.",
-    "homepage": "	https://aka.platform.uno/studio-feedback-repository",
-    "license": "https://aka.platform.uno/hot-design-terms-of-use"
+    "homepage": "https://platform.uno/studio/"
   },
   "plugins": [
     {
       "name": "uno-platform-studio",
       "description": "Skills covering MVUX, navigation, toolkit, themes (Material, Simple, shared semantic), and testing workflows for Uno Platform. The Uno documentation MCP is provided by the Uno tooling, not bundled in the plugin.",
       "source": "./plugins/uno-platform-studio",
-      "version": "1.0.0",
-      "license": "https://aka.platform.uno/hot-design-terms-of-use"
+      "version": "1.0.0"
     }
   ]
 }

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "version": "1.0.0",
-    "description": "Uno Platform skills for AI coding agents — cross-platform .NET app authoring with WinUI/Uno XAML, MVUX, Material Design, navigation, and more.",
+    "description": "Uno Platform skills for AI coding agents, cross-platform .NET app authoring with WinUI/Uno XAML, MVUX, Material Design, navigation, and more.",
     "homepage": "https://github.com/unoplatform/studio",
     "license": "Apache-2.0"
   },

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -8,8 +8,8 @@
   "metadata": {
     "version": "1.0.0",
     "description": "Uno Platform skills for AI coding agents, cross-platform .NET app authoring with WinUI/Uno XAML, MVUX, Material Design, navigation, and more.",
-    "homepage": "https://github.com/unoplatform/studio",
-    "license": "Apache-2.0"
+    "homepage": "	https://aka.platform.uno/studio-feedback-repository",
+    "license": "https://aka.platform.uno/hot-design-terms-of-use"
   },
   "plugins": [
     {
@@ -17,7 +17,7 @@
       "description": "Skills covering MVUX, navigation, toolkit, themes (Material, Simple, shared semantic), and testing workflows for Uno Platform. The Uno documentation MCP is provided by the Uno tooling, not bundled in the plugin.",
       "source": "./plugins/uno-platform-studio",
       "version": "1.0.0",
-      "license": "Apache-2.0"
+      "license": "https://aka.platform.uno/hot-design-terms-of-use"
     }
   ]
 }

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -14,7 +14,7 @@
   "plugins": [
     {
       "name": "uno-platform-studio",
-      "description": "Skills covering MVUX, navigation, toolkit, themes (Material, Simple, shared semantic), and testing workflows for Uno Platform. The Uno documentation MCP is provided by the Uno tooling (uno.devserver), not bundled in the plugin.",
+      "description": "Skills covering MVUX, navigation, toolkit, themes (Material, Simple, shared semantic), and testing workflows for Uno Platform. The Uno documentation MCP is provided by the Uno tooling, not bundled in the plugin.",
       "source": "./plugins/uno-platform-studio",
       "version": "1.0.0",
       "license": "Apache-2.0"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1,0 +1,23 @@
+{
+  "name": "uno-platform",
+  "owner": {
+    "name": "Uno Platform",
+    "url": "https://platform.uno",
+    "email": "info@platform.uno"
+  },
+  "metadata": {
+    "version": "1.0.0",
+    "description": "Uno Platform skills for AI coding agents — cross-platform .NET app authoring with WinUI/Uno XAML, MVUX, Material Design, navigation, and more.",
+    "homepage": "https://github.com/unoplatform/studio",
+    "license": "Apache-2.0"
+  },
+  "plugins": [
+    {
+      "name": "uno-platform-studio",
+      "description": "Skills covering MVUX, navigation, toolkit, themes (Material, Simple, shared semantic), and testing workflows for Uno Platform. The Uno documentation MCP is provided by the Uno tooling (uno.devserver), not bundled in the plugin.",
+      "source": "./plugins/uno-platform-studio",
+      "version": "1.0.0",
+      "license": "Apache-2.0"
+    }
+  ]
+}

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+# License
+
+Copyright (c) Uno Platform Inc. All rights reserved.
+
+The `uno-platform-studio` plugin and the bundled Uno Platform skills in this
+repository are proprietary. Their use is governed by the Uno Platform terms
+of use:
+
+<https://aka.platform.uno/hot-design-terms-of-use>

--- a/plugins/uno-platform-studio/.claude-plugin/plugin.json
+++ b/plugins/uno-platform-studio/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "uno-platform-studio",
   "version": "1.0.0",
-  "description": "Uno Platform development skills for cross-platform .NET app authoring — MVUX, navigation, Uno Toolkit, theming, and UI testing.",
+  "description": "Uno Platform development skills for cross-platform .NET app authoring: MVUX, navigation, Uno Toolkit, theming, and UI testing.",
   "author": {
     "name": "Uno Platform",
     "url": "https://platform.uno"

--- a/plugins/uno-platform-studio/.claude-plugin/plugin.json
+++ b/plugins/uno-platform-studio/.claude-plugin/plugin.json
@@ -6,8 +6,7 @@
     "name": "Uno Platform",
     "url": "https://platform.uno"
   },
-  "license": "https://aka.platform.uno/hot-design-terms-of-use",
-  "homepage": "https://aka.platform.uno/studio-feedback-repository",
-  "repository": "https://aka.platform.uno/studio-feedback-repository",
+  "homepage": "https://platform.uno/studio/",
+  "repository": "https://github.com/unoplatform/studio",
   "skills": "./skills"
 }

--- a/plugins/uno-platform-studio/.claude-plugin/plugin.json
+++ b/plugins/uno-platform-studio/.claude-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Uno Platform",
     "url": "https://platform.uno"
   },
-  "license": "Apache-2.0",
-  "homepage": "https://github.com/unoplatform/studio",
-  "repository": "https://github.com/unoplatform/studio",
+  "license": "https://aka.platform.uno/hot-design-terms-of-use",
+  "homepage": "https://aka.platform.uno/studio-feedback-repository",
+  "repository": "https://aka.platform.uno/studio-feedback-repository",
   "skills": "./skills"
 }

--- a/plugins/uno-platform-studio/.claude-plugin/plugin.json
+++ b/plugins/uno-platform-studio/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "uno-platform-studio",
+  "version": "1.0.0",
+  "description": "Uno Platform development skills for cross-platform .NET app authoring — MVUX, navigation, Uno Toolkit, theming, and UI testing.",
+  "author": {
+    "name": "Uno Platform",
+    "url": "https://platform.uno"
+  },
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/unoplatform/studio",
+  "repository": "https://github.com/unoplatform/studio",
+  "skills": "./skills"
+}

--- a/plugins/uno-platform-studio/.codex-plugin/plugin.json
+++ b/plugins/uno-platform-studio/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "uno-platform-studio",
   "version": "1.0.0",
-  "description": "Uno Platform development skills for cross-platform .NET app authoring — MVUX, navigation, Uno Toolkit, theming, and UI testing.",
+  "description": "Uno Platform development skills for cross-platform .NET app authoring: MVUX, navigation, Uno Toolkit, theming, and UI testing.",
   "author": {
     "name": "Uno Platform",
     "url": "https://platform.uno"

--- a/plugins/uno-platform-studio/.codex-plugin/plugin.json
+++ b/plugins/uno-platform-studio/.codex-plugin/plugin.json
@@ -6,8 +6,7 @@
     "name": "Uno Platform",
     "url": "https://platform.uno"
   },
-  "license": "https://aka.platform.uno/hot-design-terms-of-use",
-  "homepage": "https://aka.platform.uno/studio-feedback-repository",
-  "repository": "https://aka.platform.uno/studio-feedback-repository",
+  "homepage": "https://platform.uno/studio/",
+  "repository": "https://github.com/unoplatform/studio",
   "skills": "./skills"
 }

--- a/plugins/uno-platform-studio/.codex-plugin/plugin.json
+++ b/plugins/uno-platform-studio/.codex-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Uno Platform",
     "url": "https://platform.uno"
   },
-  "license": "Apache-2.0",
-  "homepage": "https://github.com/unoplatform/studio",
-  "repository": "https://github.com/unoplatform/studio",
+  "license": "https://aka.platform.uno/hot-design-terms-of-use",
+  "homepage": "https://aka.platform.uno/studio-feedback-repository",
+  "repository": "https://aka.platform.uno/studio-feedback-repository",
   "skills": "./skills"
 }

--- a/plugins/uno-platform-studio/.codex-plugin/plugin.json
+++ b/plugins/uno-platform-studio/.codex-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "uno-platform-studio",
+  "version": "1.0.0",
+  "description": "Uno Platform development skills for cross-platform .NET app authoring — MVUX, navigation, Uno Toolkit, theming, and UI testing.",
+  "author": {
+    "name": "Uno Platform",
+    "url": "https://platform.uno"
+  },
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/unoplatform/studio",
+  "repository": "https://github.com/unoplatform/studio",
+  "skills": "./skills"
+}

--- a/plugins/uno-platform-studio/.github/plugin.json
+++ b/plugins/uno-platform-studio/.github/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "uno-platform-studio",
   "version": "1.0.0",
-  "description": "Uno Platform development skills for cross-platform .NET app authoring — MVUX, navigation, Uno Toolkit, theming, and UI testing.",
+  "description": "Uno Platform development skills for cross-platform .NET app authoring: MVUX, navigation, Uno Toolkit, theming, and UI testing.",
   "author": {
     "name": "Uno Platform",
     "url": "https://platform.uno"

--- a/plugins/uno-platform-studio/.github/plugin.json
+++ b/plugins/uno-platform-studio/.github/plugin.json
@@ -6,8 +6,7 @@
     "name": "Uno Platform",
     "url": "https://platform.uno"
   },
-  "license": "https://aka.platform.uno/hot-design-terms-of-use",
-  "homepage": "https://aka.platform.uno/studio-feedback-repository",
-  "repository": "https://aka.platform.uno/studio-feedback-repository",
+  "homepage": "https://platform.uno/studio/",
+  "repository": "https://github.com/unoplatform/studio",
   "skills": "./skills"
 }

--- a/plugins/uno-platform-studio/.github/plugin.json
+++ b/plugins/uno-platform-studio/.github/plugin.json
@@ -6,8 +6,8 @@
     "name": "Uno Platform",
     "url": "https://platform.uno"
   },
-  "license": "Apache-2.0",
-  "homepage": "https://github.com/unoplatform/studio",
-  "repository": "https://github.com/unoplatform/studio",
+  "license": "https://aka.platform.uno/hot-design-terms-of-use",
+  "homepage": "https://aka.platform.uno/studio-feedback-repository",
+  "repository": "https://aka.platform.uno/studio-feedback-repository",
   "skills": "./skills"
 }

--- a/plugins/uno-platform-studio/.github/plugin.json
+++ b/plugins/uno-platform-studio/.github/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "uno-platform-studio",
+  "version": "1.0.0",
+  "description": "Uno Platform development skills for cross-platform .NET app authoring — MVUX, navigation, Uno Toolkit, theming, and UI testing.",
+  "author": {
+    "name": "Uno Platform",
+    "url": "https://platform.uno"
+  },
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/unoplatform/studio",
+  "repository": "https://github.com/unoplatform/studio",
+  "skills": "./skills"
+}

--- a/plugins/uno-platform-studio/README.md
+++ b/plugins/uno-platform-studio/README.md
@@ -54,6 +54,10 @@ If you don't have the Uno tooling:
 - **claude.ai / Claude Code**: install it from the [connector catalog](https://claude.ai/connectors).
 - **Other agents**: register it manually in your agent's MCP configuration. It is a remote server requiring no authentication: `https://mcp.platform.uno/v1` (HTTP transport).
 
+## UI Testing Requirement
+
+The two UI-testing skills (`uno-testing-ui`, `uno-testing-assertions`) additionally require the **Uno App MCP**, which drives a running app for visual-tree inspection, interaction, and screenshots (the `uno_app_*` tools). Like the documentation MCP, it is provided by the **Uno tooling** (integrated into the Uno Platform Dev Server), not bundled in this plugin. Agents that have only the documentation MCP cannot run these two skills; their `compatibility:` frontmatter notes the same requirement.
+
 ## Manifests
 
 | File | Consumer |

--- a/plugins/uno-platform-studio/README.md
+++ b/plugins/uno-platform-studio/README.md
@@ -38,7 +38,7 @@ Add `unoplatform/studio` to the `chat.plugins.marketplaces` setting, then instal
 
 ```text
 codex plugin marketplace add unoplatform/studio
-codex plugin install uno-platform-studio@uno-platform
+codex plugin add uno-platform-studio@uno-platform
 ```
 
 ### Agents without plugin support

--- a/plugins/uno-platform-studio/README.md
+++ b/plugins/uno-platform-studio/README.md
@@ -45,6 +45,35 @@ codex plugin add uno-platform-studio@uno-platform
 
 If your agent does not support a plugin format (Cursor, Gemini CLI, Windsurf, Cline, and others), the same skills are published as standalone folders in the repository's top-level [`skills/`](https://github.com/unoplatform/studio/tree/main/skills) directory. See its [README](https://github.com/unoplatform/studio/blob/main/skills/README.md) for copy instructions.
 
+## Uninstall
+
+### Claude Code
+
+```text
+/plugin uninstall uno-platform-studio@uno-platform
+/plugin marketplace remove uno-platform
+```
+
+(Removing the marketplace also uninstalls any plugins installed from it, so the first line is optional.)
+
+### GitHub Copilot CLI
+
+```text
+copilot plugin uninstall uno-platform-studio
+copilot plugin marketplace remove uno-platform
+```
+
+### GitHub Copilot in VS Code
+
+Right-click **uno-platform-studio** in the **Agent Plugins - Installed** view and select **Uninstall**, then remove the `unoplatform/studio` entry from the `chat.plugins.marketplaces` setting.
+
+### OpenAI Codex CLI
+
+```text
+codex plugin remove uno-platform-studio@uno-platform
+codex plugin marketplace remove uno-platform
+```
+
 ## Documentation Grounding
 
 The skills use the Uno documentation MCP (`UnoDocs`) to search and fetch official Uno Platform documentation. It is not bundled in this plugin; it comes with the **Uno tooling**, which most Studio users already have installed.

--- a/plugins/uno-platform-studio/README.md
+++ b/plugins/uno-platform-studio/README.md
@@ -1,0 +1,63 @@
+# `uno-platform-studio` Plugin
+
+Uno Platform development skills. Installs in **Claude Code**, **GitHub Copilot CLI**, **Copilot in VS Code**, and **OpenAI Codex CLI**.
+
+## Contents
+
+| Asset | Purpose |
+|---|---|
+| `skills/` | SKILL.md files covering MVUX (feeds, state, list state, selection, pagination, messaging), navigation (routes, regions, dialogs, tab/navigation shells), Uno Toolkit controls and helpers, theming (Material, Simple, shared semantic), and UI testing. |
+
+## Install
+
+### Claude Code
+
+```text
+/plugin marketplace add unoplatform/studio
+/plugin install uno-platform-studio@uno-platform
+```
+
+If prompted, run `/reload-plugins` (or restart the session) so the skills become available, then verify with `/skills`. To update later:
+
+```text
+/plugin update uno-platform-studio@uno-platform
+```
+
+### GitHub Copilot CLI
+
+```text
+copilot plugin marketplace add unoplatform/studio
+copilot plugin install uno-platform-studio@uno-platform
+```
+
+### GitHub Copilot in VS Code
+
+Add `unoplatform/studio` to the `chat.plugins.marketplaces` setting, then install **uno-platform-studio** from the agent-plugins picker.
+
+### OpenAI Codex CLI
+
+```text
+codex plugin marketplace add unoplatform/studio
+codex plugin install uno-platform-studio@uno-platform
+```
+
+### Agents without plugin support
+
+If your agent does not support a plugin format (Cursor, Gemini CLI, Windsurf, Cline, and others), the same skills are published as standalone folders in the repository's top-level [`skills/`](https://github.com/unoplatform/studio/tree/main/skills) directory. See its [README](https://github.com/unoplatform/studio/blob/main/skills/README.md) for copy instructions.
+
+## Documentation Grounding
+
+The skills use the Uno documentation MCP (`UnoDocs`) to search and fetch official Uno Platform documentation. It is not bundled in this plugin; it comes with the **Uno tooling**, which most Studio users already have installed.
+
+If you don't have the Uno tooling:
+
+- **claude.ai / Claude Code**: install it from the [connector catalog](https://claude.ai/connectors).
+- **Other agents**: register it manually in your agent's MCP configuration. It is a remote server requiring no authentication: `https://mcp.platform.uno/v1` (HTTP transport).
+
+## Manifests
+
+| File | Consumer |
+|---|---|
+| `.claude-plugin/plugin.json` | Claude Code |
+| `.github/plugin.json` | GitHub Copilot CLI + Copilot in VS Code |
+| `.codex-plugin/plugin.json` | OpenAI Codex CLI |

--- a/plugins/uno-platform-studio/README.md
+++ b/plugins/uno-platform-studio/README.md
@@ -56,7 +56,7 @@ If you don't have the Uno tooling:
 
 ## UI Testing Requirement
 
-The two UI-testing skills (`uno-testing-ui`, `uno-testing-assertions`) additionally require the **Uno App MCP**, which drives a running app for visual-tree inspection, interaction, and screenshots (the `uno_app_*` tools). Like the documentation MCP, it is provided by the **Uno tooling** (integrated into the Uno Platform Dev Server), not bundled in this plugin. Agents that have only the documentation MCP cannot run these two skills; their `compatibility:` frontmatter notes the same requirement.
+The two UI-testing skills (`uno-testing-ui`, `uno-testing-assertions`) additionally require the **Uno App MCP**, which drives a running app for visual-tree inspection, interaction, and screenshots (the `uno_app_*` tools). Like the documentation MCP, it is provided by the **Uno tooling**, not bundled in this plugin. Agents that have only the documentation MCP cannot run these two skills; their `compatibility:` frontmatter notes the same requirement.
 
 ## Manifests
 

--- a/plugins/uno-platform-studio/skills/uno-mvux-commands/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-mvux-commands/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: uno-mvux-commands
+description: "Create and use commands in MVUX for user interactions."
+when_to_use: "Use when binding a Button (or other control) to a method on the Model, understanding how methods become commands in the generated ViewModel, passing feed/state values as parameters to commands, controlling which methods generate commands (implicit vs explicit), or disabling command generation for specific methods."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: mvux
+---
+
+# MVUX Commands — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Commands Documentation
+
+Search for and fetch the commands documentation:
+
+```
+uno_platform_docs_search("MVUX commands automatic generation method invocation")
+```
+
+Primary documentation pages:
+- **Commands Reference**: `external/uno.extensions/doc/Learn/Mvux/Advanced/Commands.md`
+- **Commands How-To**: `external/uno.extensions/doc/Learn/Mvux/Walkthrough/Commands.howto.md`
+
+Fetch the reference page for complete details:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Advanced/Commands.md")
+```
+
+### Step 2: Understand Implicit Command Generation
+
+From the fetched docs, any public method on a Model automatically becomes a command in the generated ViewModel. The reference page covers:
+- Basic command generation rules
+- Using `CommandParameter` from XAML
+- Additional feed parameters (method parameter names matching feed property names)
+- The `[ImplicitCommands]` attribute to enable/disable generation
+
+### Step 3: For How-To Walkthroughs
+
+For step-by-step examples:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Walkthrough/Commands.howto.md")
+```
+
+This covers creating basic commands, using feed values in commands, can-execute logic, and disabling command generation.
+
+### Step 4: For Explicit Command Creation
+
+If the user needs manual control over commands, the reference page has an "Explicit command creation" section covering `Command.Create(...)`.
+
+## Critical Rules
+
+- **Feed parameter injection works for any feed type** (`IFeed<T>`, `IListFeed<T>`, `IState<T>`, `IListState<T>`) — the matching parameter receives a *snapshot* of the current value.
+- **But you can only mutate writable types from inside a command body.** `IState<T>` and `IListState<T>` expose `UpdateAsync` / `AddAsync` / `RemoveAsync`. `IFeed<T>` and `IListFeed<T>` are **read-only** — calling `.Update(...)`, `.UpdateAsync(...)`, `.AddAsync(...)`, or `.RemoveAsync(...)` on an injected `IListFeed`/`IFeed` is a compile error.
+- If a command needs to mutate a collection, the property on the Model must be `IListState<T>` (not `IListFeed<T>`); convert with `ListState.FromFeed(this, sourceFeed)` if needed.
+
+## Key Principles (Stable)
+
+- Any public method on a `*Model` partial record generates a command in the ViewModel
+- Commands are automatically `IAsyncCommand` — they handle async properly
+- Feed parameter injection: a method parameter whose name/type matches a Feed property gets the current feed value injected
+- Use `[ImplicitCommands(false)]` on a Model to disable automatic generation
+- Commands are bound in XAML via `Command="{Binding MethodName}"`
+- The method name becomes the command name (e.g., `Save()` → `Save` command)
+
+## Related Skills
+
+- [[uno-mvux-state-basics]] — States that commands often update
+- [[uno-mvux-feed-basics]] — Feeds whose values commands can consume
+- [[uno-mvux-selection]] — Selection-aware commands

--- a/plugins/uno-platform-studio/skills/uno-mvux-commands/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-mvux-commands/SKILL.md
@@ -59,6 +59,7 @@ If the user needs manual control over commands, the reference page has an "Expli
 - **Feed parameter injection works for any feed type** (`IFeed<T>`, `IListFeed<T>`, `IState<T>`, `IListState<T>`) — the matching parameter receives a *snapshot* of the current value.
 - **But you can only mutate writable types from inside a command body.** `IState<T>` and `IListState<T>` expose `UpdateAsync` / `AddAsync` / `RemoveAsync`. `IFeed<T>` and `IListFeed<T>` are **read-only** — calling `.Update(...)`, `.UpdateAsync(...)`, `.AddAsync(...)`, or `.RemoveAsync(...)` on an injected `IListFeed`/`IFeed` is a compile error.
 - If a command needs to mutate a collection, the property on the Model must be `IListState<T>` (not `IListFeed<T>`); convert with `ListState.FromFeed(this, sourceFeed)` if needed.
+- **When mutating via `UpdateAsync`, the updater must be pure** — derive the new value solely from the `current` value, with no captured external state or side effects. See [[uno-mvux-state-basics]] and [[uno-mvux-liststate]] for details.
 
 ## Key Principles (Stable)
 

--- a/plugins/uno-platform-studio/skills/uno-mvux-feed-basics/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-mvux-feed-basics/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: uno-mvux-feed-basics
+description: "Create and use IFeed<T> for async data in MVUX."
+when_to_use: "Use when loading data from a service or API into MVUX, creating reactive data sources that automatically handle loading/error states, transforming async data with operators like `Select` or `Where`, understanding the difference between feeds and states, or refreshing data using `Signal`."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: mvux
+---
+
+# MVUX Feed Basics — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Feed Reference Documentation
+
+Search for and fetch the feed documentation:
+
+```
+uno_platform_docs_search("MVUX Feed IFeed async data creation")
+```
+
+Primary documentation pages:
+- **Feed Reference**: `external/uno.extensions/doc/Reference/Reactive/feed.md`
+- **Simple Feed How-To**: `external/uno.extensions/doc/Learn/Mvux/Walkthrough/SimpleFeed.howto.md`
+
+Fetch the reference page for complete API details:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Reference/Reactive/feed.md")
+```
+
+### Step 2: Learn Feed Creation Methods
+
+From the fetched docs, the key factory methods on the `Feed` static class are:
+- `Feed.Async(...)` — from a `Task<T>` returning method
+- `Feed.AsyncEnumerable(...)` — from an `IAsyncEnumerable<T>`
+- `Feed.Create(...)` — from a custom async function
+
+### Step 3: For Feed Operators (Select, Where)
+
+If the user needs to transform feed data, search for operators:
+
+```
+uno_platform_docs_search("MVUX feed operators Select Where transform")
+```
+
+The feed reference page covers all operators in the "Operators" section.
+
+### Step 4: For Feed Refresh / Signal
+
+If the user needs to trigger a feed refresh:
+
+```
+uno_platform_docs_search("MVUX feed refresh Signal trigger reload")
+```
+
+The feed reference page has a section on `Signal` for manual refresh triggers.
+
+### Step 5: For How-To Walkthroughs
+
+For step-by-step examples of showing feed data on the UI:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Walkthrough/SimpleFeed.howto.md")
+```
+
+This covers binding feed data, showing errors, and using feeds inside DataTemplates.
+
+## Key Principles (Stable)
+
+- `IFeed<T>` is **read-only** — it cannot be updated from the UI
+- Feeds automatically track loading/error/none/value states
+- Feeds are **stateless** — they don't cache values (use `IState<T>` for caching)
+- The service method should accept a `CancellationToken` parameter for proper cancellation
+- Service return types should use `ValueTask<T>` or `Task<T>`
+- For collections, use `IListFeed<T>` instead (see `uno-mvux-listfeed` skill)
+
+## Related Skills
+
+- [[uno-mvux-overview]] — MVUX architecture concepts
+- [[uno-mvux-feedview]] — Displaying feed data with FeedView control
+- [[uno-mvux-state-basics]] — Mutable reactive data (IState<T>)
+- [[uno-mvux-listfeed]] — Reactive collections (IListFeed<T>)

--- a/plugins/uno-platform-studio/skills/uno-mvux-feedview/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-mvux-feedview/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: uno-mvux-feedview
+description: "Display async feed data with FeedView control."
+when_to_use: "Use when displaying data from an `IFeed<T>` or `IState<T>` in XAML, showing loading spinners, error messages, or empty-state UI automatically, customizing templates for different data states (value, progress, error, none), or binding feed data inside a `DataTemplate`."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: mvux
+---
+
+# FeedView Control — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the FeedView Documentation
+
+Search for and fetch the FeedView documentation:
+
+```
+uno_platform_docs_search("MVUX FeedView control displaying async data templates")
+```
+
+Primary documentation pages:
+- **FeedView Reference**: `external/uno.extensions/doc/Learn/Mvux/FeedView.md`
+- **FeedView How-To**: `external/uno.extensions/doc/Learn/Mvux/Walkthrough/FeedView.howto.md`
+
+Fetch the full reference page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/FeedView.md")
+```
+
+### Step 2: Understand FeedView Templates
+
+From the fetched docs, extract the available templates:
+- **ValueTemplate** (default `<DataTemplate>`) — shown when data is available
+- **ProgressTemplate** — shown during loading
+- **ErrorTemplate** — shown when an error occurs
+- **NoneTemplate** — shown when there is no data
+
+### Step 3: For FeedView How-To Walkthroughs
+
+For step-by-step implementation guidance:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Walkthrough/FeedView.howto.md")
+```
+
+This covers rendering `IFeed<T>`, `IState<T>`, customizing templates, and refresh behavior.
+
+### Step 4: For FeedView with Lists
+
+If the user is displaying a collection feed, search for:
+
+```
+uno_platform_docs_search("MVUX FeedView list feed ListView collection display")
+```
+
+Key page:
+- **ListFeed How-To**: `external/uno.extensions/doc/Learn/Mvux/Walkthrough/ListFeed.howto.md`
+
+## Key Principles (Stable)
+
+- XAML namespace: `xmlns:mvux="using:Uno.Extensions.Reactive.UI"`
+- `Source` property binds to the feed/state: `Source="{Binding MyFeed}"`
+- Inside templates, access the data via `{Binding Data}` (e.g., `{Binding Data.Name}`)
+- The default `<DataTemplate>` content child acts as the `ValueTemplate`
+- FeedView automatically provides a `Refresh` command — no need to create one manually
+- FeedView handles all state transitions (loading → value → error) without code-behind
+
+## Related Skills
+
+- [[uno-mvux-feed-basics]] — Creating feeds
+- [[uno-mvux-state-basics]] — Creating mutable states
+- [[uno-mvux-listfeed]] — Reactive collections

--- a/plugins/uno-platform-studio/skills/uno-mvux-listfeed/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-mvux-listfeed/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: uno-mvux-listfeed
+description: "Create and use IListFeed<T> for reactive collections in MVUX."
+when_to_use: "Use when loading a list of items from a service or API, displaying collections in `ListView`, `GridView`, or `ItemsRepeater`, filtering list data reactively, or choosing between `IListFeed<T>` (read-only) and `IListState<T>` (mutable)."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: mvux
+---
+
+# MVUX ListFeed — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the ListFeed Reference Documentation
+
+Search for and fetch the documentation:
+
+```
+uno_platform_docs_search("MVUX ListFeed reactive collection IListFeed")
+```
+
+Primary documentation pages:
+- **ListFeed Reference**: `external/uno.extensions/doc/Reference/Reactive/listfeed.md`
+- **ListFeed How-To**: `external/uno.extensions/doc/Learn/Mvux/Walkthrough/ListFeed.howto.md`
+
+Fetch the full reference:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Reference/Reactive/listfeed.md")
+```
+
+### Step 2: Learn ListFeed Creation Methods
+
+From the fetched docs, the key factory methods on the `ListFeed` static class:
+- `ListFeed.Async(...)` — from a method returning `Task<IImmutableList<T>>`
+- `ListFeed.AsyncEnumerable(...)` — from an `IAsyncEnumerable<IImmutableList<T>>`
+- `ListFeed.PaginatedAsync(...)` — for paginated/infinite scroll (see `uno-mvux-pagination` skill)
+
+### Step 3: For ListFeed Operators
+
+The reference page covers operators like `Where`, `Select`, and `AsFeed`. These operate on individual items in the collection.
+
+### Step 4: For How-To Walkthroughs
+
+For step-by-step examples:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Walkthrough/ListFeed.howto.md")
+```
+
+This covers loading a list, showing it with FeedView, filtering with `Where`, and when to use feeds vs states.
+
+### Step 5: For Displaying Lists in XAML
+
+The how-to page shows how to bind `IListFeed<T>` to `ListView` via `FeedView` and access items through `{Binding Data}`.
+
+## Key Principles (Stable)
+
+- `IListFeed<T>` is **read-only** — use `IListState<T>` for add/remove/update
+- Service methods should return `ValueTask<IImmutableList<T>>` (from `System.Collections.Immutable`)
+- Operators like `Where` and `Select` work on individual items, not the list itself
+- ListFeed automatically handles loading/error/empty states
+- Use `IListFeed<T>` when data is pulled from a service and is read-only
+- Use `IListState<T>` when you need to edit the collection client-side
+
+## Key Equality Requirement (Critical)
+
+**All item types used in `IListFeed<T>` MUST support key equality** via `Uno.Extensions.Equality.IKeyEquatable<T>`. Without key equality, MVUX cannot distinguish between a modified entity and a completely different one, causing full list re-renders instead of granular item updates (flickering, lost scroll position, broken animations).
+
+### Automatic generation (recommended)
+
+For `partial record` types, key equality is **auto-generated** when the record has a property named `Id` or `Key`:
+
+```csharp
+public partial record Person(Guid Id, string Name, int Age);
+// IKeyEquatable<Person> is generated automatically — Id is the key
+```
+
+### Explicit key configuration
+
+Use `[Key]` attribute when the key property has a different name, or for composite keys:
+
+```csharp
+public partial record OrderLine(
+    [property: Key] Guid OrderId,
+    [property: Key] int LineNumber,
+    string Product,
+    decimal Price);
+```
+
+Either `Uno.Extensions.Equality.KeyAttribute` or `System.ComponentModel.DataAnnotations.KeyAttribute` can be used.
+
+### Assembly-level defaults
+
+Configure which property names are auto-detected as keys:
+
+```csharp
+[assembly: ImplicitKeyEquality("Id", "Key", "EntityId")]
+```
+
+### Disabling generation
+
+If auto-generation causes issues on a specific type:
+
+```csharp
+[ImplicitKeys(IsEnabled = false)]
+public partial record MyItem(Guid Id, string Name);
+```
+
+### Rules
+
+- The item type **must** be a `partial record` (or manually implement `IKeyEquatable<T>`)
+- At least one key property is required — without it, every update replaces the entire list in the UI
+- Key properties define **identity** (same entity); non-key properties define **state** (changed data)
+- `KeyEquals` returns `true` when two instances represent the same entity, even if other properties differ
+
+## Related Skills
+
+- [[uno-mvux-feed-basics]] — Single-value feeds
+- [[uno-mvux-liststate]] — Mutable reactive collections
+- [[uno-mvux-selection]] — Selection management with list feeds
+- [[uno-mvux-pagination]] — Infinite scroll / paginated lists
+- [[uno-mvux-feedview]] — Displaying feed data in XAML

--- a/plugins/uno-platform-studio/skills/uno-mvux-liststate/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-mvux-liststate/SKILL.md
@@ -120,6 +120,18 @@ public partial record MyItem(Guid Id, string Name);
 - `KeyEquals` returns `true` when two instances represent the same entity, even if other properties differ
 - `UpdateAsync` uses key equality to find the existing item to replace — without it, the update silently fails or replaces the wrong item
 
+## Updater Purity (Critical)
+
+The function passed to `UpdateAsync` (and to the item-level updaters) **must be pure**: derive the new value *solely* from the `current` value it receives, with no capture of external/mutable variables and no side effects. MVUX is stateless and lockless and applies the updater against the current cached value, so an updater that depends on anything other than its input is not guaranteed to produce a stable result. Project the value you were given onto a new immutable value (use `with` expressions on records); never reach outside the lambda for state.
+
+```csharp
+// Correct: pure projection of the current item
+await Items.UpdateAsync(item => item with { IsDone = true });
+
+// Wrong: result captures external mutable state
+await Items.UpdateAsync(_ => _externalItem);
+```
+
 ## Related Skills
 
 - [[uno-mvux-listfeed]] — Read-only reactive collections

--- a/plugins/uno-platform-studio/skills/uno-mvux-liststate/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-mvux-liststate/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: uno-mvux-liststate
+description: "Create and use IListState<T> for mutable reactive collections in MVUX."
+when_to_use: "Use when adding, removing, or updating items in a collection, managing item selection in a list, two-way binding with collections, synchronizing list changes with services via messaging, or converting a read-only `IListFeed<T>` into a mutable `IListState<T>`."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: mvux
+---
+
+# MVUX ListState — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the ListState Documentation
+
+There is no dedicated ListState reference page — it shares documentation with ListFeed and State. Search for:
+
+```
+uno_platform_docs_search("MVUX ListState mutable collection add remove update selection")
+```
+
+Key documentation pages:
+- **ListFeed Reference** (includes ListState): `external/uno.extensions/doc/Reference/Reactive/listfeed.md`
+- **State Reference** (includes list state creation): `external/uno.extensions/doc/Reference/Reactive/state.md`
+- **Usage in Apps** (ListState patterns): `external/uno.extensions/doc/Reference/Reactive/in-apps.md`
+
+Fetch the in-apps reference for practical patterns:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Reference/Reactive/in-apps.md")
+```
+
+### Step 2: For ListState Creation
+
+- `ListState<T>.Empty(this)` — starts with no items
+- `ListState.Async(this, asyncFunc)` — loads initial data from async source
+- Can add `.Selection(...)` to track selected items
+
+### Step 3: For ListState Mutations
+
+Search for mutation operations:
+
+```
+uno_platform_docs_search("MVUX ListState add remove update items operation")
+```
+
+Key operations: `AddAsync`, `RemoveAllAsync`, `UpdateAsync`, `InsertAsync`.
+
+### Step 4: For Messaging Integration
+
+If the user needs list updates from service CRUD operations:
+
+```
+uno_platform_docs_search("MVUX messaging EntityMessage ListState observe")
+```
+
+See the `uno-mvux-messaging` skill for full details.
+
+## Key Principles (Stable)
+
+- `IListState<T>` is **mutable** — supports add/remove/update
+- Created with `ListState<T>.Empty(this)` or `ListState.Async(this, ...)`
+- Supports two-way binding and selection management
+- Records should implement key equality for proper update detection
+- Use `.Selection(state)` to connect selection tracking
+- For read-only lists, prefer `IListFeed<T>` instead
+
+## Key Equality Requirement (Critical)
+
+**All item types used in `IListState<T>` MUST support key equality** via `Uno.Extensions.Equality.IKeyEquatable<T>`. This is essential for `IListState<T>` because mutation operations (`UpdateAsync`, `RemoveAllAsync`, selection tracking) rely on key equality to identify which item to target. Without it, MVUX cannot match an updated instance to its original, causing broken updates, lost selection state, and full list re-renders.
+
+### Automatic generation (recommended)
+
+For `partial record` types, key equality is **auto-generated** when the record has a property named `Id` or `Key`:
+
+```csharp
+public partial record TodoItem(Guid Id, string Title, bool IsComplete);
+// IKeyEquatable<TodoItem> is generated automatically — Id is the key
+```
+
+### Explicit key configuration
+
+Use `[Key]` attribute when the key property has a different name, or for composite keys:
+
+```csharp
+public partial record OrderLine(
+    [property: Key] Guid OrderId,
+    [property: Key] int LineNumber,
+    string Product,
+    decimal Price);
+```
+
+Either `Uno.Extensions.Equality.KeyAttribute` or `System.ComponentModel.DataAnnotations.KeyAttribute` can be used.
+
+### Assembly-level defaults
+
+Configure which property names are auto-detected as keys:
+
+```csharp
+[assembly: ImplicitKeyEquality("Id", "Key", "EntityId")]
+```
+
+### Disabling generation
+
+If auto-generation causes issues on a specific type:
+
+```csharp
+[ImplicitKeys(IsEnabled = false)]
+public partial record MyItem(Guid Id, string Name);
+```
+
+### Rules
+
+- The item type **must** be a `partial record` (or manually implement `IKeyEquatable<T>`)
+- At least one key property is required — without it, mutations and selection cannot identify items
+- Key properties define **identity** (same entity); non-key properties define **state** (changed data)
+- `KeyEquals` returns `true` when two instances represent the same entity, even if other properties differ
+- `UpdateAsync` uses key equality to find the existing item to replace — without it, the update silently fails or replaces the wrong item
+
+## Related Skills
+
+- [[uno-mvux-listfeed]] — Read-only reactive collections
+- [[uno-mvux-selection]] — Selection management
+- [[uno-mvux-messaging]] — Syncing list state with entity changes
+- [[uno-mvux-records]] — Immutable record design with key equality

--- a/plugins/uno-platform-studio/skills/uno-mvux-messaging/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-mvux-messaging/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: uno-mvux-messaging
+description: "Use messaging to sync MVUX states with entity changes."
+when_to_use: "Use when CRUD operations that should update all views showing the same data, decoupling services from models — services broadcast changes, models react, keeping multiple views/pages in sync when shared entities change, or using `EntityMessage<T>` with CommunityToolkit.Mvvm messenger."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: mvux
+---
+
+# MVUX Messaging — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Messaging Documentation
+
+Search for and fetch the messaging documentation:
+
+```
+uno_platform_docs_search("MVUX messaging EntityMessage synchronization CRUD")
+```
+
+Primary documentation pages:
+- **Messaging Reference**: `external/uno.extensions/doc/Learn/Mvux/Advanced/Messaging.md`
+- **Messaging How-To**: `external/uno.extensions/doc/Learn/Mvux/Walkthrough/Messaging.howto.md`
+
+Fetch the reference page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Advanced/Messaging.md")
+```
+
+### Step 2: For How-To Walkthroughs
+
+For step-by-step implementation:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Walkthrough/Messaging.howto.md")
+```
+
+This covers when to use messaging, sending entity messages from services, observing changes in models, and manual message handling.
+
+### Step 3: Understand the Architecture
+
+From the fetched docs, the messaging pattern involves:
+1. **Service** sends `EntityMessage<T>` via `IMessenger.Send(...)`
+2. **Model** uses `.Observe(messenger)` on a `ListState` to auto-apply changes
+3. **Entity changes** (Created/Updated/Deleted) are applied to the matching state
+
+### Step 4: For Manual Message Handling
+
+If the user needs custom logic when messages arrive, the reference page covers the `Update` extension methods that allow manual application of `EntityMessage<T>` to states.
+
+## Key Principles (Stable)
+
+- Register `IMessenger` as a singleton in DI: `services.AddSingleton<IMessenger, WeakReferenceMessenger>()`
+- `EntityMessage<T>` carries an entity change type (Created, Updated, Deleted) and the entity
+- `.Observe(messenger)` on a `ListState` auto-applies incoming entity changes
+- Records need key equality for matching (see `uno-mvux-records` skill)
+- Namespace: `Uno.Extensions.Reactive.Messaging`
+
+## Related Skills
+
+- [[uno-mvux-liststate]] — Mutable collections that messaging updates
+- [[uno-mvux-records]] — Key equality for entity matching
+- [[uno-mvux-commands]] — Commands that trigger CRUD operations

--- a/plugins/uno-platform-studio/skills/uno-mvux-overview/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-mvux-overview/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: uno-mvux-overview
+description: "Understand MVUX (Model-View-Update-eXtended) architecture in Uno Platform."
+when_to_use: "Use when learning the MVUX architecture, comparing MVUX to MVVM or other patterns, setting up a new Uno Platform project with MVUX, or understanding immutable data flow with feeds and states."
+metadata:
+  author: uno-platform
+  version: "2.5"
+  category: mvux
+---
+
+# MVUX Overview — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the MVUX Overview Documentation
+
+Search for and fetch the core MVUX overview page:
+
+```
+uno_platform_docs_search("MVUX overview Model View Update eXtended architecture")
+```
+
+The primary documentation page is:
+- **MVUX Overview**: `external/uno.extensions/doc/Learn/Mvux/Overview.md`
+
+Fetch the full page for comprehensive details:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Overview.md")
+```
+
+### Step 2: Understand Key Concepts
+
+From the fetched documentation, extract and explain:
+
+1. **What MVUX is**: Model-View-Update-eXtended — an MVU variant that supports XAML data binding
+2. **How it differs from MVVM**: Unidirectional data flow, immutable records, automatic state management
+3. **Core types**: `IFeed<T>`, `IState<T>`, `IListFeed<T>`, `IListState<T>`
+4. **Code generation**: Models with `*Model` suffix generate corresponding `*ViewModel` classes
+5. **FeedView control**: The UI control that handles loading/error/value states automatically
+
+### Step 3: For Project Setup Details
+
+If the user needs to set up MVUX in a project, search for setup instructions:
+
+```
+uno_platform_docs_search("MVUX project setup UnoFeatures add MVUX existing app")
+```
+
+Key doc page for setup:
+- **How to set up an MVUX project**: `external/uno.extensions/doc/Learn/Mvux/Tutorials/HowTo-MvuxProject.md`
+
+### Step 4: For MVUX vs MVVM Comparison
+
+If the user wants a comparison, the overview page contains a detailed MVVM vs MVUX data flow section. Fetch:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Overview.md")
+```
+
+Focus on the sections: "What is MVUX?", "eXtended", "MVVM vs MVUX Data Flow", and "Weather App Example".
+
+## Key Principles (Stable)
+
+- Models MUST be `partial record` types with a `Model` suffix (e.g., `MainModel`)
+- All data entities should be C# records (immutable)
+- MVUX requires `<UnoFeatures>MVUX</UnoFeatures>` in the project file
+- The generated ViewModel is what gets set as the `DataContext`, not the Model itself
+- Services are injected via constructor parameters on the record
+
+## Choosing the right MVUX skill
+
+When unsure which MVUX skill applies, pick by intent:
+
+### Getting started
+
+- [[uno-mvux-records]] — Design immutable data models
+- [[uno-mvux-feed-basics]] — Load async data
+
+### Displaying data
+
+- [[uno-mvux-feedview]] — `FeedView` control for all states
+- [[uno-mvux-listfeed]] — Display collections
+
+### User input
+
+- [[uno-mvux-state-basics]] — Two-way binding with states
+- [[uno-mvux-commands]] — Button actions and commands
+
+### Advanced features
+
+- [[uno-mvux-liststate]] — Mutable collections
+- [[uno-mvux-selection]] — Selection management
+- [[uno-mvux-pagination]] — Infinite scroll
+- [[uno-mvux-messaging]] — Entity synchronization

--- a/plugins/uno-platform-studio/skills/uno-mvux-pagination/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-mvux-pagination/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: uno-mvux-pagination
+description: "Implement paginated and infinite scrolling lists in MVUX."
+when_to_use: "Use when loading large datasets incrementally (page by page), implementing infinite scroll in `ListView`, `GridView`, or `ItemsRepeater`, working with APIs that use offset/limit or cursor-based pagination, or using `ListFeed.PaginatedAsync(...)`."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: mvux
+---
+
+# MVUX Pagination — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Pagination Documentation
+
+Search for and fetch the pagination documentation:
+
+```
+uno_platform_docs_search("MVUX pagination infinite scrolling PaginatedAsync")
+```
+
+Primary documentation pages:
+- **Pagination Reference**: `external/uno.extensions/doc/Learn/Mvux/Advanced/Pagination.md`
+- **Pagination in Chefs App**: `external/uno.chefs/doc/mvux/Pagination.md`
+- **Usage in Apps (Pagination section)**: `external/uno.extensions/doc/Reference/Reactive/in-apps.md`
+
+Fetch the reference page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Advanced/Pagination.md")
+```
+
+### Step 2: For Practical Examples
+
+Fetch the Chefs app example for a real-world implementation:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.chefs/doc/mvux/Pagination.md")
+```
+
+### Step 3: Understand Pagination Types
+
+From the fetched docs:
+- **Index-based**: Uses page size and start index (`PageRequest.DesiredSize`, `PageRequest.CurrentCount`)
+- **Cursor/keyset-based**: Uses a cursor token for the next page
+
+### Step 4: For ItemsRepeater Integration
+
+If the user is using `ItemsRepeater` for incremental loading:
+
+```
+uno_platform_docs_search("ItemsRepeater MVUX pagination incremental loading")
+```
+
+Key page:
+- **ItemsRepeater Extensions**: `external/uno.toolkit.ui/doc/helpers/walkthroughs/itemsrepeater-extensions.howto.md`
+
+## Key Principles (Stable)
+
+- Use `ListFeed.PaginatedAsync(...)` to create a paginated list feed
+- The callback receives a `PageRequest` with `DesiredSize` and `CurrentCount`
+- `ListView` supports incremental loading automatically when bound to a paginated feed
+- For `ItemsRepeater`, use the Toolkit's `ItemsRepeaterExtensions` for incremental loading support
+- Pagination works with both index-based and cursor-based APIs
+
+## Related Skills
+
+- [[uno-mvux-listfeed]] — Non-paginated list feeds
+- [[uno-mvux-selection]] — Selection with paginated lists
+- [[uno-toolkit-itemsrepeater-extensions]] — ItemsRepeater incremental loading

--- a/plugins/uno-platform-studio/skills/uno-mvux-records/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-mvux-records/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: uno-mvux-records
+description: "Use immutable records effectively with MVUX."
+when_to_use: "Use when designing data models/entities for MVUX, understanding why MVUX requires records (immutability), implementing key equality for proper item matching in lists, using `with` expressions to create modified copies, or understanding `partial record` requirements for Model classes."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: mvux
+---
+
+# Working with Records in MVUX — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the MVUX Overview (Records Section)
+
+The MVUX overview covers why records are essential:
+
+```
+uno_platform_docs_search("MVUX immutable records data model code generation")
+```
+
+Primary documentation page:
+- **MVUX Overview**: `external/uno.extensions/doc/Learn/Mvux/Overview.md`
+
+Fetch and look for the "Model" and "Creating your own" sections:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Overview.md")
+```
+
+### Step 2: For Key Equality in Messaging/Selection
+
+If the user needs key equality for entity matching (messaging, selection), search for:
+
+```
+uno_platform_docs_search("MVUX key equality entity matching record identifier")
+```
+
+The messaging reference covers how records are matched by key:
+- **Messaging Reference**: `external/uno.extensions/doc/Learn/Mvux/Advanced/Messaging.md`
+
+### Step 3: For General C# Records
+
+If the user needs help with C# record syntax itself, this is standard C# language knowledge — records provide immutability, value equality, `with` expressions, and deconstruction.
+
+## Key Equality Requirement (Critical)
+
+**Record types used as items in MVUX collections (`IListFeed<T>`, `IListState<T>`) MUST support key equality via `Uno.Extensions.Equality.IKeyEquatable<T>`.** Without it, MVUX cannot distinguish a modified entity from a different one — every change forces a full list re-render (flickering, lost scroll position, broken animations). For single-value `IState<T>` / `IFeed<T>`, key equality matters for messaging-driven entity matching.
+
+### Automatic generation (recommended)
+
+For `partial record` types, `IKeyEquatable<T>` is **auto-generated** when the record has a property named `Id` or `Key`:
+
+```csharp
+public partial record Person(Guid Id, string Name, int Age);
+// IKeyEquatable<Person> is generated automatically — Id is the key
+```
+
+### Explicit key configuration
+
+Use `[Key]` (from `Uno.Extensions.Equality` or `System.ComponentModel.DataAnnotations`) when the key property has a different name, or for composite keys:
+
+```csharp
+public partial record OrderLine(
+    [property: Key] Guid OrderId,
+    [property: Key] int LineNumber,
+    string Product,
+    decimal Price);
+```
+
+### Assembly-level defaults
+
+Configure which property names are auto-detected as keys:
+
+```csharp
+[assembly: ImplicitKeyEquality("Id", "Key", "EntityId")]
+```
+
+### Disabling generation
+
+If auto-generation causes issues on a specific type:
+
+```csharp
+[ImplicitKeys(IsEnabled = false)]
+public partial record MyItem(Guid Id, string Name);
+```
+
+### Do not invent the interface name
+
+The interface is exactly **`Uno.Extensions.Equality.IKeyEquatable<T>`**. Do not introduce a generic `IHasKey<T>` or similar invented name — the framework will not recognise it.
+
+### Rules
+
+- The item type **must** be a `partial record` (or manually implement `IKeyEquatable<T>`)
+- At least one key property is required — without it, every update replaces the entire list in the UI
+- Key properties define **identity** (same entity); non-key properties define **state** (changed data)
+- `KeyEquals` returns `true` when two instances represent the same entity, even if other properties differ
+
+## Key Principles (Stable)
+
+- **Data entities** should be `record` types (immutable, value equality)
+- **Model classes** must be `partial record` with a `Model` suffix for code generation
+- Records use `with` expressions to create modified copies: `entity with { Name = "New" }`
+- Value equality means two records with the same data are considered equal
+- Positional records: `public record Person(string Name, int Age);` — concise syntax
+- Models inject services via constructor: `public partial record MainModel(IMyService Service)`
+
+## Related Skills
+
+- [[uno-mvux-overview]] — MVUX architecture requiring records
+- [[uno-mvux-messaging]] — Entity matching depends on key equality
+- [[uno-mvux-selection]] — Selection tracking relies on equality

--- a/plugins/uno-platform-studio/skills/uno-mvux-selection/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-mvux-selection/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: uno-mvux-selection
+description: "Implement item selection in MVUX lists."
+when_to_use: "Use when tracking the selected item(s) in a `ListView`, `GridView`, or other selector, implementing single-item selection with `IState<T>`, implementing multi-item selection with `IState<IImmutableList<T>>`, reacting to selection changes in the Model, or manual (programmatic) selection of items."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: mvux
+---
+
+# MVUX Selection — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Selection Documentation
+
+Search for and fetch the selection documentation:
+
+```
+uno_platform_docs_search("MVUX selection Selection method IListFeed IListState")
+```
+
+Primary documentation pages:
+- **Selection Reference**: `external/uno.extensions/doc/Learn/Mvux/Advanced/Selection.md`
+- **Selection How-To**: `external/uno.extensions/doc/Learn/Mvux/Walkthrough/Selection.howto.md`
+- **Selection in Chefs App**: `external/uno.chefs/doc/mvux/Selection.md`
+
+Fetch the reference page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Advanced/Selection.md")
+```
+
+### Step 2: For How-To Walkthroughs
+
+For step-by-step examples:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Walkthrough/Selection.howto.md")
+```
+
+This covers single selection, multi selection, checking selection from commands, and programmatic selection.
+
+### Step 3: Understand Selection Patterns
+
+From the fetched docs:
+- **Single selection**: `.Selection(selectedState)` where `selectedState` is `IState<T?>`
+- **Multi-selection**: `.Selection(selectedStates)` where `selectedStates` is `IState<IImmutableList<T>>`
+- **Manual selection**: Use `IListState<T>` instead of `IListFeed<T>` for programmatic item selection
+
+### Step 4: For Selection with Commands
+
+If the user needs to use the selected item in a command (e.g., "Edit" button):
+
+```
+uno_platform_docs_search("MVUX selection command check current selected item button")
+```
+
+## Key Principles (Stable)
+
+- Use `.Selection(state)` operator on `IListFeed<T>` or `IListState<T>` to enable selection tracking
+- Single selection: `IState<T?>` holds the selected item
+- Multi-selection: `IState<IImmutableList<T>>` holds selected items
+- The `ListView` SelectionMode must be set appropriately (Single, Multiple, Extended)
+- Selection sync happens automatically between the UI control and the state
+- For programmatic/manual selection, use `IListState<T>` (not `IListFeed<T>`)
+
+## Related Skills
+
+- [[uno-mvux-listfeed]] — Read-only collections with selection
+- [[uno-mvux-liststate]] — Mutable collections with selection
+- [[uno-mvux-commands]] — Commands that use selected items

--- a/plugins/uno-platform-studio/skills/uno-mvux-state-basics/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-mvux-state-basics/SKILL.md
@@ -62,6 +62,16 @@ See also the `uno-mvux-commands` skill.
 - **The mutation method is `UpdateAsync`** — `public static ValueTask UpdateAsync<T>(this IState<T> state, Func<T?, T?> updater, CancellationToken ct = default)`.
 - **There is no `Update` method on `IState<T>`** — calling `state.Update(x => ...)` is a compile error. The baseline model frequently emits this wrong name; the skill must keep the correct name front-and-centre.
 - `UpdateAsync` returns `ValueTask` — `await` it from inside an `async` method (typically a command body).
+- **The updater must be pure** — derive the new value *solely* from the `current` parameter it receives. Do not capture or read external/mutable variables, and do not perform side effects inside it. MVUX is stateless and lockless: the updater is applied against the state's current cached value, so a function that depends on anything other than `current` is not guaranteed to produce a stable result. The official docs model this by declaring the updater as a `static` local function, which the compiler prevents from capturing enclosing state:
+
+  ```csharp
+  // Correct: a pure projection of the value you were given
+  static int increment(int current) => current + 1;
+  await Counter.UpdateAsync(increment);
+
+  // Wrong: result is not derived from `current`, it captures external state
+  await Counter.UpdateAsync(_ => _someExternalField);
+  ```
 
 ## Key Principles (Stable)
 

--- a/plugins/uno-platform-studio/skills/uno-mvux-state-basics/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-mvux-state-basics/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: uno-mvux-state-basics
+description: "Create and use IState<T> for mutable reactive data in MVUX."
+when_to_use: "Use when implementing two-way data binding (e.g., TextBox, Slider, ToggleSwitch), accepting and storing user input, maintaining editable application state, programmatically updating a value from a command or service call, or understanding the difference between `IFeed<T>` (read-only) and `IState<T>` (read/write)."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: mvux
+---
+
+# MVUX State Basics — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the State Reference Documentation
+
+Search for and fetch the state documentation:
+
+```
+uno_platform_docs_search("MVUX State IState mutable two-way binding")
+```
+
+Primary documentation page:
+- **State Reference**: `external/uno.extensions/doc/Reference/Reactive/state.md`
+
+Fetch the full reference:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Reference/Reactive/state.md")
+```
+
+### Step 2: Learn State Creation Methods
+
+From the fetched docs, the key factory methods on the `State` and `State<T>` classes:
+- `State<T>.Empty(this)` — starts with no value
+- `State<T>.Value(this, initialValue)` — starts with a sync value
+- `State.Async(this, asyncFunc)` — initial value from async source
+- `State.FromFeed(this, feed)` — wraps a feed as mutable state
+
+### Step 3: For Updating State Programmatically
+
+The state reference page covers `UpdateAsync`, `SetAsync`, and `ForEach` for subscribing to changes. Focus on the "Update: How to update a state" section.
+
+### Step 4: For Two-Way Binding Examples
+
+The state reference page includes a "Binding the View to a State" section showing how XAML two-way binding works automatically with generated ViewModels.
+
+### Step 5: For Commands with State
+
+If the user needs commands that interact with states:
+
+```
+uno_platform_docs_search("MVUX commands state update async method")
+```
+
+See also the `uno-mvux-commands` skill.
+
+## Critical Rules
+
+- **The mutation method is `UpdateAsync`** — `public static ValueTask UpdateAsync<T>(this IState<T> state, Func<T?, T?> updater, CancellationToken ct = default)`.
+- **There is no `Update` method on `IState<T>`** — calling `state.Update(x => ...)` is a compile error. The baseline model frequently emits this wrong name; the skill must keep the correct name front-and-centre.
+- `UpdateAsync` returns `ValueTask` — `await` it from inside an `async` method (typically a command body).
+
+## Key Principles (Stable)
+
+- `IState<T>` is **mutable** — it supports read and write operations
+- States **cache** their current value (unlike feeds which are stateless)
+- The generated ViewModel exposes states as two-way bindable properties automatically
+- `State<T>.Empty(this)` requires passing `this` as the owner for lifecycle management
+- Use `await state.UpdateAsync(current => newValue)` to update programmatically
+- Use `state.ForEach(async (value, ct) => { ... })` to react to changes
+
+## Related Skills
+
+- [[uno-mvux-feed-basics]] — Read-only reactive data (IFeed<T>)
+- [[uno-mvux-commands]] — Command generation and interaction with states
+- [[uno-mvux-liststate]] — Mutable reactive collections (IListState<T>)
+- [[uno-mvux-feedview]] — Displaying state data with FeedView

--- a/plugins/uno-platform-studio/skills/uno-navigation-code/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-navigation-code/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: uno-navigation-code
+description: "Programmatic navigation via `INavigator` extension methods (`NavigateRouteAsync`, `NavigateViewModelAsync`, `NavigateBackAsync`, and the `*ForResultAsync` overloads)."
+when_to_use: "Use when navigating from a ViewModel, code-behind, or a service, including back-navigation (`NavigateBackAsync`), result-returning navigation (`NavigateViewModelForResultAsync<TViewModel, TResult>`, `NavigateBackWithResultAsync`), or choosing the right `Navigate*Async` overload for the scenario."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: navigation
+---
+
+# Uno Navigation from Code — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Code Navigation Documentation
+
+```
+uno_platform_docs_search("Uno Navigation code programmatic NavigateRouteAsync NavigateViewModelAsync")
+```
+
+Primary documentation pages:
+- **Navigation via Code Behind (Chefs)**: `external/uno.chefs/doc/navigation/NavigationCodeBehind.md`
+- **Navigation Overview (Code section)**: `external/uno.extensions/doc/Learn/Navigation/NavigationOverview.md`
+
+Fetch the Chefs code-behind page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.chefs/doc/navigation/NavigationCodeBehind.md")
+```
+
+### Step 2: For Specific Navigation Methods
+
+The documentation covers two parallel families:
+
+**Non-result overloads** — navigate to a destination, don't expect a return value:
+- `NavigateRouteAsync("routeName")` — navigate by route string
+- `NavigateViewAsync<TView>()` — navigate to a specific view type
+- `NavigateViewModelAsync<TViewModel>()` — navigate to the route registered for a ViewModel type
+- `NavigateDataAsync<TData>(data)` — navigate with data; the destination is resolved from the data type
+- `NavigateBackAsync()` — pop one level off the back stack
+
+**Result overloads** — navigate AND retrieve a typed result from the destination page:
+- `NavigateRouteForResultAsync<TResult>("routeName")`
+- `NavigateViewForResultAsync<TView, TResult>()`
+- `NavigateViewModelForResultAsync<TViewModel, TResult>()`
+- `NavigateDataForResultAsync<TData, TResult>()`
+- `NavigateBackWithResultAsync(data)` — used on the destination page to return data to the caller
+
+The result overloads return `Task<NavigationResult<TResult>>`. The caller awaits, then reads `.Result` for the returned value.
+
+### Step 3: For Advanced Navigation Techniques
+
+```
+uno_platform_docs_search("Uno Navigation advanced back stack clear navigate techniques")
+```
+
+Key page:
+- **Advanced Page Navigation**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/AdvancedPageNavigation.md`
+
+## Critical Rules
+
+- **Pick the correct overload for the navigation scenario.** Non-result overloads (`NavigateViewModelAsync<TViewModel>`) are for one-way navigation. Result overloads (`NavigateViewModelForResultAsync<TViewModel, TResult>`) are for request-and-await-response flows where the destination page calls `NavigateBackWithResultAsync(data)` to return a value. Using the non-result overload when a return value is needed silently throws away the result.
+- Navigation methods are **extension methods on `INavigator`** — they are not extension methods on `string`, `Route`, or any view type. Get an `INavigator` instance first (constructor injection or `this.GetNavigator()`), then call `await navigator.Navigate*Async(...)`.
+
+## Key Principles (Stable)
+
+- Get `INavigator` via constructor injection or `this.GetNavigator()` extension method
+- All navigation methods are async; non-result overloads return `Task<NavigationResponse>`, result overloads return `Task<NavigationResultResponse<TResult>>`
+- `NavigateViewModelAsync` is the most common one-way overload — maps to the route registered for that ViewModel
+- `NavigateBackAsync()` goes back one level
+- Combine with `Qualifiers.ClearBackStack` to clear navigation history
+- Always `await` navigation calls
+
+## Common Pitfall Example
+
+The second Critical Rule above (extension methods on `INavigator`) is the most-seen mistake. Concrete example:
+
+```csharp
+// WRONG: CS1929 — string has no NavigateRouteAsync
+await "/details".NavigateRouteAsync(...);
+
+// CORRECT: Get INavigator first
+var navigator = this.GetNavigator();
+await navigator.NavigateRouteAsync(this, route: "/details");
+```
+
+In XAML, prefer the `uen:Navigation.Request` attached property instead of code-behind navigation:
+
+```xml
+<Button Content="Go to Details"
+        uen:Navigation.Request="Details"/>
+```
+
+## Related Skills
+
+- [[uno-navigation-routes]] — Route registration (required for code navigation)
+- [[uno-navigation-data]] — Passing data during navigation
+- [[uno-navigation-qualifiers]] — Navigation qualifiers (clear back stack, etc.)
+- [[uno-navigation-xaml]] — Declarative alternative to code navigation

--- a/plugins/uno-platform-studio/skills/uno-navigation-contentcontrol/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-navigation-contentcontrol/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: uno-navigation-contentcontrol
+description: "Implement ContentControl region navigation for dynamic content areas without back stack."
+when_to_use: "Use when swapping content in a specific area of the layout without maintaining back stack, using ContentControl as a navigation target region, or simple content switching that doesn't need navigation history."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: navigation
+---
+
+# Uno Navigation ContentControl — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the ContentControl Navigation Documentation
+
+```
+uno_platform_docs_search("Uno Navigation ContentControl region content switching")
+```
+
+Primary documentation pages:
+- **Define Regions**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRegions.md`
+- **Navigation Region Reference**: `external/uno.extensions/doc/Reference/Navigation/NavigationRegion.md`
+
+Fetch the regions reference:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Reference/Navigation/NavigationRegion.md")
+```
+
+### Step 2: For Alternative Approaches
+
+If the user needs visibility-based switching instead:
+
+See the `uno-navigation-panel-visibility` skill.
+
+## Key Principles (Stable)
+
+- ContentControl can be a navigation target region
+- No back stack — content simply replaced
+- Use `uen:Region.Attached="True"` on the ContentControl
+- Good for sidebar detail panes, settings containers, or single-area content swaps
+
+## Related Skills
+
+- [[uno-navigation-regions]] — Region concepts
+- [[uno-navigation-panel-visibility]] — Visibility-based switching

--- a/plugins/uno-platform-studio/skills/uno-navigation-data/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-navigation-data/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: uno-navigation-data
+description: "Pass and receive data during navigation in Uno Platform applications."
+when_to_use: "Use when passing data (objects, IDs, filters) from one page to another, receiving data in a ViewModel via constructor injection, returning results from a page back to the caller, using `NavigateDataAsync`, `NavigateBackWithResultAsync`, or setting up `DataViewMap` or `ResultDataViewMap` for data-based routes."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: navigation
+---
+
+# Uno Navigation Data Passing — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Data Passing Documentation
+
+```
+uno_platform_docs_search("Uno Navigation data passing receive NavigateDataAsync constructor injection")
+```
+
+Primary documentation pages:
+- **Passing Navigation Data (Chefs)**: `external/uno.chefs/doc/navigation/PassingNavigationData.md`
+- **Pass Data During Navigation**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/DisplayItemDetails.md`
+
+Fetch the Chefs data passing page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.chefs/doc/navigation/PassingNavigationData.md")
+```
+
+### Step 2: For Route Configuration with Data
+
+Data-based navigation requires proper route registration:
+
+```
+uno_platform_docs_search("Uno Navigation DataViewMap ResultDataViewMap route data type")
+```
+
+### Step 3: For Returning Results
+
+If the user needs a round-trip (navigate, pick data, return):
+
+The Chefs page covers `NavigateBackWithResultAsync` and `ResultDataViewMap` patterns.
+
+### Step 4: For XAML Data Passing
+
+For passing data declaratively:
+
+```
+uno_platform_docs_search("Uno Navigation XAML Navigation.Data binding pass")
+```
+
+## Key Principles (Stable)
+
+- Data is received via constructor dependency injection in the target ViewModel
+- `DataViewMap` associates a data type with a View/ViewModel for data-based navigation
+- `ResultDataViewMap` additionally specifies a result type for round-trip navigation
+- `NavigateBackWithResultAsync(data)` returns data to the calling page
+- Routes must be configured in `RegisterRoutes` to support data types
+- `Navigation.Data` attached property enables data passing in XAML
+
+## Related Skills
+
+- [[uno-navigation-routes]] — Route registration with data types
+- [[uno-navigation-code]] — Programmatic navigation methods
+- [[uno-navigation-xaml]] — XAML data binding for navigation

--- a/plugins/uno-platform-studio/skills/uno-navigation-dialogs/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-navigation-dialogs/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: uno-navigation-dialogs
+description: "Display dialogs, flyouts, modals, and message prompts using Uno Platform Navigation Extensions."
+when_to_use: "Use when showing a simple alert, confirmation, or message dialog with OK/Cancel options, getting a user response from a dialog via `ShowMessageDialogAsync`, showing a dialog or flyout via navigation, using `ContentDialog` as a navigation modal, understanding the difference between flyout (Page-based) and modal (ContentDialog-based), or getting results from dialog navigation."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: navigation
+---
+
+# Uno Navigation Dialogs — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Dialog Navigation Documentation
+
+```
+uno_platform_docs_search("Uno Navigation dialogs flyouts ContentDialog modal ShowMessageDialogAsync confirmation alert")
+```
+
+Primary documentation pages:
+- **Display Dialogs as Flyouts or Modals**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/ShowDialog.md`
+- **How-To: Display a Dialog**: `external/uno.extensions/doc/Learn/Navigation/HowTo-ShowDialog.md`
+
+Fetch the walkthrough:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/Walkthrough/ShowDialog.md")
+```
+
+### Step 2: For Simple Message Dialogs
+
+Use `navigator.ShowMessageDialogAsync(...)` for the simplest case — a title, message, and buttons that return the user's choice. No route registration needed.
+
+### Step 3: For Flyout vs Modal
+
+- **Flyout**: navigation target is a `Page` → displayed as flyout
+- **Modal**: navigation target is a `ContentDialog` → displayed as modal
+
+### Step 4: For Dialog Results
+
+If the user needs to return data from a dialog:
+
+See the `uno-navigation-data` skill for `NavigateBackWithResultAsync`.
+
+## Key Principles (Stable)
+
+- Message dialogs are the simplest dialog type — title, message, and buttons via `navigator.ShowMessageDialogAsync(...)`, no route registration required
+- Use `!/` qualifier prefix or `Qualifiers.Dialog` to open a `Page`/`ContentDialog`-based dialog via navigation
+- If the target is a `Page`, it displays as a flyout
+- If the target is a `ContentDialog`, it displays as a modal
+- Dialog results can be returned via `NavigateBackWithResultAsync` (or directly from `ShowMessageDialogAsync` for the simple case)
+- Dialogs participate in the navigation system — they have proper back-stack handling
+
+## Related Skills
+
+- [[uno-navigation-qualifiers]] — Qualifier prefixes
+- [[uno-navigation-data]] — Passing/returning data
+- [[uno-navigation-code]] — Programmatic navigation

--- a/plugins/uno-platform-studio/skills/uno-navigation-navigationview/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-navigation-navigationview/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: uno-navigation-navigationview
+description: "Implement NavigationView navigation in Uno Platform using region-based navigation. Provides complete, compilable shell template for sidebar/hamburger navigation. Use for >5 pages, hierarchical content, or desktop/enterprise apps."
+when_to_use: "Use when more than 5 top-level pages, hierarchical or content-heavy apps, desktop / enterprise apps, prompt mentions \"dashboard\", \"admin\", \"desktop\", \"sidebar\", or \"drawer\", building a sidebar navigation pattern, or implementing a hamburger menu."
+metadata:
+  author: uno-platform
+  version: "3.3"
+  category: navigation
+---
+
+# Uno Navigation with NavigationView — Agent Skill
+
+## Reference Templates
+
+For complete, compilable shell XAML with parameterized placeholders, see:
+
+**`references/shell-navigationview-template.md`** — Contains:
+- Icon lookup table (Home, Search, Settings, Profile, etc.)
+- SHELL_PAGE_NAME.xaml — Without Settings variant
+- SHELL_PAGE_NAME.xaml — With Settings variant
+- SHELL_PAGE_NAME.xaml.cs — Settings code-behind (`Region.SetName` for built-in Settings item)
+- Page template (XAML + code-behind)
+- Route registration template
+- Substitution rules
+- Localization template (Resources.resw)
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the NavigationView Navigation Documentation
+
+```
+uno_platform_docs_search("Uno Navigation NavigationView sidebar hamburger region")
+```
+
+Primary documentation pages:
+- **Define Regions (NavigationView section)**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRegions.md`
+- **Responsive Shell**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/ResponsiveShell.md`
+
+Fetch the define regions page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRegions.md")
+```
+
+Focus on the "Using Regions with NavigationView" section.
+
+### Step 2: For Responsive Navigation
+
+If the user needs adaptive navigation (NavigationView on desktop, TabBar on mobile):
+
+See the `uno-navigation-responsive-shell` skill.
+
+## Key Principles (Stable)
+
+- NavigationView uses region-based navigation to link menu items to content
+- Parent container needs `uen:Region.Attached="True"`
+- NavigationView needs `uen:Region.Attached="True"`
+- Each `NavigationViewItem` uses `uen:Region.Name="RouteName"` to map to content
+- Content area uses a Grid with `uen:Region.Attached="True"` and `uen:Region.Navigator="Visibility"`
+- XAML namespace: `xmlns:uen="using:Uno.Extensions.Navigation.UI"`
+
+## Critical Rules
+
+- The root `Grid` with `uen:Region.Attached="True"` enables region navigation for the entire shell
+- `uen:Region.Attached="True"` MUST also be on the `NavigationView` itself
+- The content area `Grid` inside `NavigationView` needs BOTH `uen:Region.Attached="True"` AND `uen:Region.Navigator="Visibility"`
+- **The content area Grid with `Region.Navigator="Visibility"` must be empty in XAML.** Do not add `Collapsed` child elements for each route. The navigation framework resolves registered routes and injects the corresponding views at runtime.
+- The Settings item is NOT a `NavigationViewItem` in `MenuItems` — use `Loaded` event + `Region.SetName` in code-behind
+- Route names in `RouteMap` MUST match the `uen:Region.Name` values in `SHELL_PAGE_NAME.xaml`
+- Page routes are nested under the `"Main"` route so only the content area updates, not the entire page
+- Do NOT use `Region.Attached="True"` inside `Shell.xaml` — only in `SHELL_PAGE_NAME.xaml`
+
+## Related Skills
+
+- [[uno-navigation-regions]] — Region concepts
+- [[uno-navigation-responsive-shell]] — Adaptive NavigationView + TabBar
+- [[uno-navigation-panel-visibility]] — Visibility-based content switching details
+- [[uno-navigation-tabbar]] — TabBar alternative
+- [[uno-navigation-routes]] — Route registration details

--- a/plugins/uno-platform-studio/skills/uno-navigation-navigationview/references/shell-navigationview-template.md
+++ b/plugins/uno-platform-studio/skills/uno-navigation-navigationview/references/shell-navigationview-template.md
@@ -1,0 +1,238 @@
+# Shell: Sidebar NavigationView — Reference Templates
+
+Ready-to-use templates for a NavigationView (sidebar/hamburger) navigation shell. Copy, substitute placeholders, and use.
+
+## Icon Lookup Table
+
+| Page Concept | Glyph | Unicode |
+|---|---|---|
+| Home / Dashboard | `&#xE80F;` | `\uE80F` |
+| Search / Explore | `&#xE721;` | `\uE721` |
+| Settings / Gear | `&#xE713;` | `\uE713` |
+| Profile / Person | `&#xE77B;` | `\uE77B` |
+| Favorites / Heart | `&#xE734;` | `\uE734` |
+| Add / Plus | `&#xE710;` | `\uE710` |
+| List / Bullets | `&#xE8FD;` | `\uE8FD` |
+| Chart / Analytics | `&#xE9D9;` | `\uE9D9` |
+| Calendar / Date | `&#xE787;` | `\uE787` |
+| Mail / Messages | `&#xE715;` | `\uE715` |
+| Cart / Shopping | `&#xE7BF;` | `\uE7BF` |
+| Notification / Bell | `&#xEA8F;` | `\uEA8F` |
+
+## Required XAML Namespaces
+
+```xml
+xmlns:uen="using:Uno.Extensions.Navigation.UI"
+```
+
+## SHELL_PAGE_NAME.xaml (Without Settings)
+
+Use this variant when the plan does NOT include a Settings page. The content area Grid with `Region.Navigator="Visibility"` must be **empty** — the navigation framework injects views at runtime from registered routes.
+
+```xml
+<Page x:Class="SHELL_PAGE_CLASS"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:uen="using:Uno.Extensions.Navigation.UI"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid uen:Region.Attached="True">
+        <NavigationView x:Name="NavView"
+                        uen:Region.Attached="True"
+                        IsSettingsVisible="False"
+                        IsBackButtonVisible="Collapsed">
+            <NavigationView.MenuItems>
+                <!-- REPLACE: One NavigationViewItem per page -->
+                <NavigationViewItem uen:Region.Name="PAGE1_NAME"
+                                    Content="PAGE1_LABEL">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="PAGE1_ICON_GLYPH" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem uen:Region.Name="PAGE2_NAME"
+                                    Content="PAGE2_LABEL">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="PAGE2_ICON_GLYPH" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem uen:Region.Name="PAGE3_NAME"
+                                    Content="PAGE3_LABEL">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="PAGE3_ICON_GLYPH" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+            </NavigationView.MenuItems>
+
+            <!-- Content area: visibility-based region switching (empty — framework injects views) -->
+            <Grid uen:Region.Attached="True"
+                  uen:Region.Navigator="Visibility" />
+        </NavigationView>
+    </Grid>
+</Page>
+```
+
+## SHELL_PAGE_NAME.xaml (With Settings)
+
+Use this variant when the plan includes a Settings page. The NavigationView Settings item requires code-behind to set its region name.
+
+```xml
+<Page x:Class="SHELL_PAGE_CLASS"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:uen="using:Uno.Extensions.Navigation.UI"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid uen:Region.Attached="True">
+        <NavigationView x:Name="NavView"
+                        uen:Region.Attached="True"
+                        IsSettingsVisible="True"
+                        IsBackButtonVisible="Collapsed"
+                        Loaded="NavView_Loaded">
+            <NavigationView.MenuItems>
+                <!-- REPLACE: One NavigationViewItem per non-Settings page -->
+                <NavigationViewItem uen:Region.Name="PAGE1_NAME"
+                                    Content="PAGE1_LABEL">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="PAGE1_ICON_GLYPH" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem uen:Region.Name="PAGE2_NAME"
+                                    Content="PAGE2_LABEL">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="PAGE2_ICON_GLYPH" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+            </NavigationView.MenuItems>
+
+            <!-- Content area: visibility-based region switching (empty — framework injects views) -->
+            <Grid uen:Region.Attached="True"
+                  uen:Region.Navigator="Visibility" />
+        </NavigationView>
+    </Grid>
+</Page>
+```
+
+## SHELL_PAGE_NAME.xaml.cs (With Settings — code-behind for Region.SetName)
+
+```csharp
+namespace PAGE_NAMESPACE;
+
+public sealed partial class SHELL_PAGE_NAME : Page
+{
+    public SHELL_PAGE_NAME()
+    {
+        this.InitializeComponent();
+    }
+
+    private void NavView_Loaded(object sender, RoutedEventArgs e)
+    {
+        // The built-in Settings item is not in MenuItems, so we set its Region.Name in code
+        if (NavView.SettingsItem is NavigationViewItem settingsItem)
+        {
+            Uno.Extensions.Navigation.UI.Region.SetName(settingsItem, "Settings");
+        }
+    }
+}
+```
+
+## Page Template (PageName.xaml)
+
+Create one `.xaml` + `.xaml.cs` pair per page in the appropriate project folder.
+
+```xml
+<Page x:Class="PAGE_CLASS"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <TextBlock Text="PAGE_NAME"
+                   FontSize="24"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center" />
+    </Grid>
+</Page>
+```
+
+## Page Template (PageName.xaml.cs)
+
+```csharp
+namespace PAGE_NAMESPACE;
+
+public sealed partial class PAGE_NAMEPage : Page
+{
+    public PAGE_NAMEPage()
+    {
+        this.InitializeComponent();
+    }
+}
+```
+
+## Route Registration (App.xaml.cs)
+
+```csharp
+private static void RegisterRoutes(IViewRegistry views, IRouteRegistry routes)
+{
+    views.Register(
+        new ViewMap(ViewModel: typeof(ShellModel)),
+        new ViewMap<SHELL_PAGE_NAME>(),
+        // REPLACE: One ViewMap per page
+        new ViewMap<PAGE1_NAMEPage>(),
+        new ViewMap<PAGE2_NAMEPage>(),
+        new ViewMap<PAGE3_NAMEPage>()
+    );
+
+    routes.Register(
+        new RouteMap("", View: views.FindByViewModel<ShellModel>(),
+            Nested:
+            [
+                new RouteMap("Main", View: views.FindByView<SHELL_PAGE_NAME>(),
+                    IsDefault: true,
+                    Nested:
+                    [
+                        // REPLACE: One RouteMap per page
+                        new RouteMap("PAGE1_NAME", View: views.FindByView<PAGE1_NAMEPage>(), IsDefault: true),
+                        new RouteMap("PAGE2_NAME", View: views.FindByView<PAGE2_NAMEPage>()),
+                        new RouteMap("PAGE3_NAME", View: views.FindByView<PAGE3_NAMEPage>())
+                    ]
+                )
+            ]
+        )
+    );
+}
+```
+
+## Substitution Rules
+
+1. Replace `SHELL_PAGE_CLASS` with the full `x:Class` value for the shell page (e.g., `MyApp.Presentation.MainPage`)
+2. Replace `SHELL_PAGE_NAME` with the class name of the shell page (e.g., `MainPage`). This is the page that hosts the NavigationView navigation chrome.
+3. Replace `PAGE_CLASS` with the full `x:Class` value for each content page (e.g., `MyApp.Presentation.DashboardPage`)
+4. Replace `PAGE_NAMESPACE` with the namespace for content pages (e.g., `MyApp.Presentation`)
+5. Replace `PAGE1_NAME`, `PAGE2_NAME`, `PAGE3_NAME` with route names from the plan (e.g., `Dashboard`, `Reports`, `Users`)
+6. Replace `PAGE1_LABEL`, `PAGE2_LABEL`, `PAGE3_LABEL` with display labels (or use `x:Uid` for localization)
+7. Replace `PAGE1_ICON_GLYPH`, etc. with glyphs from the Icon Lookup Table above (e.g., `&#xE80F;`)
+8. Add or remove `NavigationViewItem` entries to match the number of pages in the plan
+9. Choose the "With Settings" or "Without Settings" variant based on whether the plan includes a Settings page
+10. If using Settings, include `new RouteMap("Settings", View: views.FindByView<SettingsPage>())` in the nested routes
+
+## Route Registration Rules
+
+1. Route names (first argument to `RouteMap`) MUST match the `uen:Region.Name` values in `SHELL_PAGE_NAME.xaml`
+2. Page routes are nested under the `"Main"` route so only the content area updates, not the entire page
+3. The empty string `""` route is the root shell route
+4. `ViewMap` entries without a ViewModel are valid.
+
+## Localization Template (Strings/en/Resources.resw)
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="PAGE1_NAME_NavItem.Content" xml:space="preserve">
+    <value>PAGE1_LABEL</value>
+  </data>
+  <data name="PAGE1_NAME_NavItem.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>PAGE1_LABEL navigation item</value>
+  </data>
+  <!-- Repeat for each nav item -->
+</root>
+```

--- a/plugins/uno-platform-studio/skills/uno-navigation-panel-visibility/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-navigation-panel-visibility/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: uno-navigation-panel-visibility
+description: "Implement visibility-based navigation using Panel or Grid controls."
+when_to_use: "Use when implementing lightweight content switching without `Frame` overhead via `Region.Navigator=\"Visibility\"`, when serving as the content area inside `TabBar`, `NavigationView`, or responsive shells, or when all registered views should stay in the visual tree after injection."
+metadata:
+  author: uno-platform
+  version: "3.4"
+  category: navigation
+---
+
+# Uno Navigation Panel Visibility — Agent Skill
+
+This skill covers visibility-based navigation where the framework injects registered route views into an empty `Grid` and switches between them by toggling `Visibility`. This is the content-area pattern used inside TabBar, NavigationView, and responsive shell layouts.
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Visibility Navigation Documentation
+
+```
+uno_platform_docs_search("Uno Navigation visibility based panel Grid Region.Navigator content switch")
+```
+
+Primary documentation pages:
+- **Define Regions**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRegions.md`
+- **Navigation Region Reference**: `external/uno.extensions/doc/Reference/Navigation/NavigationRegion.md`
+
+Fetch the define regions walkthrough:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRegions.md")
+```
+
+## Key Principles (Stable)
+
+- Set `uen:Region.Navigator="Visibility"` on the content container Grid
+- Set `uen:Region.Attached="True"` on the same Grid
+- **The Grid marked with `uen:Region.Navigator="Visibility"` must be empty in XAML.** Do not add `Collapsed` child elements for each route. The navigation framework resolves registered routes and injects the corresponding views at runtime.
+- After injection, children are toggled via Visibility — all remain in the visual tree
+- Good for small numbers of views where you want instant switching
+- No back stack — just visibility toggles
+
+## Typical Usage Pattern
+
+The visibility region Grid appears as the content area inside navigation shells:
+
+```xml
+<!-- Inside a TabBar or NavigationView shell -->
+<Grid uen:Region.Attached="True"
+      uen:Region.Navigator="Visibility" />
+```
+
+The framework creates view instances from registered `RouteMap` entries and places them as children of this Grid, managing their `Visibility` as navigation occurs.
+
+## Critical Rules
+
+- The Grid MUST have both `uen:Region.Attached="True"` AND `uen:Region.Navigator="Visibility"`
+- The Grid MUST be empty — do NOT pre-populate with collapsed child elements
+- Route names in `RouteMap` determine which views get injected
+- The parent navigation control (TabBar, NavigationView) drives which child becomes visible
+
+## Related Skills
+
+- [[uno-navigation-regions]] — Region concepts
+- [[uno-navigation-contentcontrol]] — ContentControl-based switching (alternative)
+- [[uno-navigation-navigationview]] — NavigationView shell using visibility regions
+- [[uno-navigation-tabbar]] — TabBar shell using visibility regions
+- [[uno-navigation-responsive-shell]] — Responsive shell using visibility regions

--- a/plugins/uno-platform-studio/skills/uno-navigation-qualifiers/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-navigation-qualifiers/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: uno-navigation-qualifiers
+description: "Use navigation qualifiers in Uno Platform to control back stack behavior."
+when_to_use: "Use when clearing the navigation back stack (e.g., after login), removing specific pages from back stack, opening dialogs/flyouts via navigation, navigating to nested regions, or using qualifier prefixes in route strings."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: navigation
+---
+
+# Uno Navigation Qualifiers — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Qualifiers Documentation
+
+```
+uno_platform_docs_search("Uno Navigation qualifiers back stack clear dialog Qualifiers class")
+```
+
+Primary documentation pages:
+- **Navigation Qualifiers Reference**: `external/uno.extensions/doc/Reference/Navigation/Qualifiers.md`
+- **Advanced Page Navigation**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/AdvancedPageNavigation.md`
+- **XAML Navigation Qualifiers (Chefs)**: `external/uno.chefs/doc/navigation/XamlNavigation.md`
+
+Fetch the qualifiers reference:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Reference/Navigation/Qualifiers.md")
+```
+
+### Step 2: For Advanced Back Stack Management
+
+Fetch the advanced page navigation walkthrough:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/Walkthrough/AdvancedPageNavigation.md")
+```
+
+### Step 3: For Code-Behind Qualifiers
+
+If using qualifiers from code:
+
+```
+uno_platform_docs_search("Uno Navigation Qualifiers.ClearBackStack code behind NavigateViewModelAsync")
+```
+
+Key page:
+- **How-To Advanced Page Navigation**: `external/uno.extensions/doc/Learn/Navigation/Advanced/HowTo-AdvancedPageNavigation.md`
+
+## Key Principles (Stable)
+
+- `-/` prefix: clears back stack (e.g., `uen:Navigation.Request="-/Login"`)
+- `!/` prefix: opens a dialog/flyout
+- Qualifiers can be combined with route names
+- From code: use `Qualifiers.ClearBackStack`, `Qualifiers.Dialog`, etc.
+- `Qualifiers` class is in `Uno.Extensions.Navigation` namespace
+- Common scenario: after login, navigate to main page with `-/` to prevent back navigation to login
+
+## Related Skills
+
+- [[uno-navigation-code]] — Programmatic navigation
+- [[uno-navigation-xaml]] — XAML navigation with qualifiers
+- [[uno-navigation-dialogs]] — Dialog navigation

--- a/plugins/uno-platform-studio/skills/uno-navigation-regions/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-navigation-regions/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: uno-navigation-regions
+description: "Implement region-based navigation in Uno Platform using Region.Attached, Region.Name, and Region.Navigator properties."
+when_to_use: "Use when defining navigation regions within a page, linking a TabBar, NavigationView, or other control to a content area, visibility-based content switching within regions, building navigation hierarchies with nested regions, or using `Region.Attached`, `Region.Name`, and `Region.Navigator`."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: navigation
+---
+
+# Uno Navigation Regions — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Regions Documentation
+
+```
+uno_platform_docs_search("Uno Navigation regions Region.Attached Region.Name navigator")
+```
+
+Primary documentation pages:
+- **Define Regions Walkthrough**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRegions.md`
+- **How-To: Define Regions**: `external/uno.extensions/doc/Learn/Navigation/HowTo-Regions.md`
+- **Navigation Region Reference**: `external/uno.extensions/doc/Reference/Navigation/NavigationRegion.md`
+
+Fetch the walkthrough:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRegions.md")
+```
+
+### Step 2: For Common Pitfalls
+
+Fetch the how-to page for important warnings:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/HowTo-Regions.md")
+```
+
+Critical warning: Do NOT use `Region.Attached="True"` inside Shell.xaml or ExtendedSplashScreen content.
+
+### Step 3: For NavigationView with Regions
+
+The walkthrough includes a section on "Using Regions with NavigationView".
+
+### Step 4: For Visibility-Based Navigation  
+
+If the user needs visibility-based content switching:
+
+See the `uno-navigation-panel-visibility` skill.
+
+## Key Principles (Stable)
+
+- `uen:Region.Attached="True"` — enables region-based navigation on a container
+- `uen:Region.Name="RouteName"` — identifies which route this region represents
+- `uen:Region.Navigator="Visibility"` — switches content by toggling visibility
+- **CRITICAL**: Never use `Region.Attached="True"` inside Shell.xaml content — the navigation host isn't ready yet
+- Regions mirror the navigation control hierarchy
+- Navigation controls (TabBar, NavigationView) and content areas must share a common parent with `Region.Attached="True"`
+
+## Related Skills
+
+- [[uno-navigation-setup]] — Navigation host configuration
+- [[uno-navigation-panel-visibility]] — Visibility-based navigation
+- [[uno-navigation-navigationview]] — NavigationView with regions
+- [[uno-navigation-tabbar]] — TabBar with regions

--- a/plugins/uno-platform-studio/skills/uno-navigation-responsive-shell/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-navigation-responsive-shell/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: uno-navigation-responsive-shell
+description: "Implement responsive navigation shells that adapt between TabBar and NavigationView based on screen size. Provides complete, compilable shell template with VisualStateManager breakpoints."
+when_to_use: "Use when an app must work well on both mobile and desktop, upgrading a single-form-factor shell to responsive, or switching between `TabBar` on mobile and `NavigationView` on desktop via `VisualStateManager` or `ResponsiveExtension`."
+metadata:
+  author: uno-platform
+  version: "3.5"
+  category: navigation
+---
+
+# Uno Navigation Responsive Shell — Agent Skill
+
+## Reference Templates
+
+For a complete, compilable responsive shell XAML with parameterized placeholders, see:
+
+**`references/shell-responsive-template.md`** — Contains:
+- Icon lookup table (Home, Search, Settings, Profile, etc.)
+- SHELL_PAGE_NAME.xaml responsive shell template (NavigationView + TabBar + VisualStateManager)
+- Breakpoint summary table (Narrow / Normal / Wide)
+- Route registration template
+- Substitution rules
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Responsive Shell Documentation
+
+```
+uno_platform_docs_search("Uno Navigation responsive shell NavigationView TabBar adaptive screen size")
+```
+
+Primary documentation page:
+- **Build Responsive Navigation Layouts**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/ResponsiveShell.md`
+
+Fetch the walkthrough:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/Walkthrough/ResponsiveShell.md")
+```
+
+### Step 2: For ResponsiveExtension
+
+If using the Toolkit's `ResponsiveExtension`:
+
+```
+uno_platform_docs_search("Uno Toolkit responsive extension screen size breakpoints")
+```
+
+See also the `uno-toolkit-responsive` skill.
+
+## Key Principles (Stable)
+
+- Use VisualStateManager with adaptive triggers to show/hide different navigation controls
+- Both TabBar and NavigationView can use the same region names for shared content
+- `ResponsiveExtension` can toggle Visibility based on breakpoints (Normal, Wide, etc.)
+- The content area remains the same — only the navigation control changes
+- Common pattern: TabBar at bottom for mobile, NavigationView sidebar for desktop
+- XAML namespaces: `xmlns:uen="using:Uno.Extensions.Navigation.UI"` and `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Breakpoint Summary
+
+| State | Width | TabBar | NavigationView Pane | Use Case |
+|---|---|---|---|---|
+| Narrow | < 700px | Visible | Hidden | Mobile phones |
+| Normal | 700-999px | Hidden | Visible (auto) | Tablets |
+| Wide | >= 1000px | Hidden | Visible (expanded) | Desktops |
+
+## Critical Rules
+
+- Both navigation controls (`NavigationView` and `TabBar`) MUST have `uen:Region.Attached="True"`
+- Both MUST use identical `uen:Region.Name` values for the same pages — they share the content area
+- The `VisualStateManager` goes on the root `Grid` with `uen:Region.Attached="True"`
+- The `Narrow` state has NO `StateTriggers` — it is the default (smallest) state
+- States are ordered by ascending width: Narrow (default) < Normal (700px) < Wide (1000px)
+- The shared content area with `Region.Navigator="Visibility"` serves both navigation controls
+- **The content area Grid with `Region.Navigator="Visibility"` must be empty in XAML.** Do not add `Collapsed` child elements for each route. The navigation framework resolves registered routes and injects the corresponding views at runtime.
+- Do NOT use `Region.Attached="True"` inside `Shell.xaml` — only in `SHELL_PAGE_NAME.xaml`
+
+## Related Skills
+
+- [[uno-navigation-tabbar]] — Mobile-only shell
+- [[uno-navigation-navigationview]] — Desktop-only shell
+- [[uno-navigation-panel-visibility]] — Visibility-based content switching details
+- [[uno-toolkit-responsive]] — Responsive markup extensions
+- [[uno-navigation-regions]] — Region concepts

--- a/plugins/uno-platform-studio/skills/uno-navigation-responsive-shell/references/shell-responsive-template.md
+++ b/plugins/uno-platform-studio/skills/uno-navigation-responsive-shell/references/shell-responsive-template.md
@@ -1,0 +1,203 @@
+# Shell: Responsive NavigationView + TabBar — Reference Templates
+
+Ready-to-use template for a responsive navigation shell that switches between a bottom TabBar on narrow screens and a sidebar NavigationView on wide screens.
+
+## Icon Lookup Table
+
+| Page Concept | Glyph | Unicode |
+|---|---|---|
+| Home / Dashboard | `&#xE80F;` | `\uE80F` |
+| Search / Explore | `&#xE721;` | `\uE721` |
+| Settings / Gear | `&#xE713;` | `\uE713` |
+| Profile / Person | `&#xE77B;` | `\uE77B` |
+| Favorites / Heart | `&#xE734;` | `\uE734` |
+| Add / Plus | `&#xE710;` | `\uE710` |
+| List / Bullets | `&#xE8FD;` | `\uE8FD` |
+| Chart / Analytics | `&#xE9D9;` | `\uE9D9` |
+| Calendar / Date | `&#xE787;` | `\uE787` |
+| Mail / Messages | `&#xE715;` | `\uE715` |
+
+## Required XAML Namespaces
+
+```xml
+xmlns:uen="using:Uno.Extensions.Navigation.UI"
+xmlns:utu="using:Uno.Toolkit.UI"
+```
+
+## SHELL_PAGE_NAME.xaml (Responsive Shell)
+
+The content area Grid with `Region.Navigator="Visibility"` must be **empty** — the navigation framework injects views at runtime from registered routes.
+
+```xml
+<Page x:Class="SHELL_PAGE_CLASS"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:uen="using:Uno.Extensions.Navigation.UI"
+      xmlns:utu="using:Uno.Toolkit.UI"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid uen:Region.Attached="True">
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup>
+                <!-- Narrow: TabBar visible, NavigationView pane hidden -->
+                <VisualState x:Name="Narrow">
+                    <VisualState.Setters>
+                        <Setter Target="BottomTabs.Visibility" Value="Visible" />
+                        <Setter Target="NavView.IsPaneToggleButtonVisible" Value="False" />
+                        <Setter Target="NavView.PaneDisplayMode" Value="LeftMinimal" />
+                        <Setter Target="NavView.IsPaneOpen" Value="False" />
+                    </VisualState.Setters>
+                </VisualState>
+                <!-- Normal (>=700px): NavigationView visible, TabBar hidden -->
+                <VisualState x:Name="Normal">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="700" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="BottomTabs.Visibility" Value="Collapsed" />
+                        <Setter Target="NavView.IsPaneToggleButtonVisible" Value="True" />
+                        <Setter Target="NavView.IsPaneVisible" Value="True" />
+                        <Setter Target="NavView.PaneDisplayMode" Value="Auto" />
+                    </VisualState.Setters>
+                </VisualState>
+                <!-- Wide (>=1000px): NavigationView expanded -->
+                <VisualState x:Name="Wide">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="1000" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="BottomTabs.Visibility" Value="Collapsed" />
+                        <Setter Target="NavView.IsPaneToggleButtonVisible" Value="True" />
+                        <Setter Target="NavView.IsPaneVisible" Value="True" />
+                        <Setter Target="NavView.PaneDisplayMode" Value="Auto" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+
+        <!-- NavigationView: visible on Normal/Wide, pane hidden on Narrow -->
+        <NavigationView x:Name="NavView"
+                        uen:Region.Attached="True"
+                        IsSettingsVisible="False"
+                        IsBackButtonVisible="Collapsed">
+            <NavigationView.MenuItems>
+                <!-- REPLACE: One NavigationViewItem per page -->
+                <NavigationViewItem uen:Region.Name="PAGE1_NAME"
+                                    Content="PAGE1_LABEL">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="PAGE1_ICON_GLYPH" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem uen:Region.Name="PAGE2_NAME"
+                                    Content="PAGE2_LABEL">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="PAGE2_ICON_GLYPH" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem uen:Region.Name="PAGE3_NAME"
+                                    Content="PAGE3_LABEL">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="PAGE3_ICON_GLYPH" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+            </NavigationView.MenuItems>
+
+            <NavigationView.Content>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <!-- Shared content area: used by both NavigationView and TabBar (empty — framework injects views) -->
+                    <Grid Grid.Row="0"
+                          uen:Region.Attached="True"
+                          uen:Region.Navigator="Visibility" />
+
+                    <!-- Bottom TabBar: visible on Narrow, hidden on Normal/Wide -->
+                    <utu:TabBar x:Name="BottomTabs"
+                                Grid.Row="1"
+                                uen:Region.Attached="True"
+                                Style="{StaticResource BottomTabBarStyle}"
+                                Visibility="Collapsed">
+                        <!-- REPLACE: One TabBarItem per page (must mirror NavigationViewItems) -->
+                        <utu:TabBarItem uen:Region.Name="PAGE1_NAME"
+                                        Content="PAGE1_LABEL"
+                                        Style="{StaticResource MaterialBottomTabBarItemStyle}">
+                            <utu:TabBarItem.Icon>
+                                <FontIcon Glyph="PAGE1_ICON_GLYPH" />
+                            </utu:TabBarItem.Icon>
+                        </utu:TabBarItem>
+                        <utu:TabBarItem uen:Region.Name="PAGE2_NAME"
+                                        Content="PAGE2_LABEL"
+                                        Style="{StaticResource MaterialBottomTabBarItemStyle}">
+                            <utu:TabBarItem.Icon>
+                                <FontIcon Glyph="PAGE2_ICON_GLYPH" />
+                            </utu:TabBarItem.Icon>
+                        </utu:TabBarItem>
+                        <utu:TabBarItem uen:Region.Name="PAGE3_NAME"
+                                        Content="PAGE3_LABEL"
+                                        Style="{StaticResource MaterialBottomTabBarItemStyle}">
+                            <utu:TabBarItem.Icon>
+                                <FontIcon Glyph="PAGE3_ICON_GLYPH" />
+                            </utu:TabBarItem.Icon>
+                        </utu:TabBarItem>
+                    </utu:TabBar>
+                </Grid>
+            </NavigationView.Content>
+        </NavigationView>
+    </Grid>
+</Page>
+```
+
+## Breakpoint Summary
+
+| State | Width | TabBar | NavigationView Pane | Use Case |
+|---|---|---|---|---|
+| Narrow | < 700px | Visible | Hidden | Mobile phones |
+| Normal | 700-999px | Hidden | Visible (auto) | Tablets |
+| Wide | >= 1000px | Hidden | Visible (expanded) | Desktops |
+
+## Route Registration (App.xaml.cs)
+
+Same pattern as TabBar and NavigationView shells:
+
+```csharp
+private static void RegisterRoutes(IViewRegistry views, IRouteRegistry routes)
+{
+    views.Register(
+        new ViewMap(ViewModel: typeof(ShellModel)),
+        new ViewMap<SHELL_PAGE_NAME>(),
+        new ViewMap<PAGE1_NAMEPage>(),
+        new ViewMap<PAGE2_NAMEPage>(),
+        new ViewMap<PAGE3_NAMEPage>()
+    );
+
+    routes.Register(
+        new RouteMap("", View: views.FindByViewModel<ShellModel>(),
+            Nested:
+            [
+                new RouteMap("Main", View: views.FindByView<SHELL_PAGE_NAME>(),
+                    IsDefault: true,
+                    Nested:
+                    [
+                        new RouteMap("PAGE1_NAME", View: views.FindByView<PAGE1_NAMEPage>(), IsDefault: true),
+                        new RouteMap("PAGE2_NAME", View: views.FindByView<PAGE2_NAMEPage>()),
+                        new RouteMap("PAGE3_NAME", View: views.FindByView<PAGE3_NAMEPage>())
+                    ]
+                )
+            ]
+        )
+    );
+}
+```
+
+## Substitution Rules
+
+1. Replace `SHELL_PAGE_CLASS` with the full `x:Class` value for the shell page (e.g., `MyApp.Presentation.MainPage`)
+2. Replace `SHELL_PAGE_NAME` with the class name of the shell page (e.g., `MainPage`). This is the page that hosts the responsive navigation chrome.
+3. Replace `PAGE1_NAME`, `PAGE2_NAME`, `PAGE3_NAME` with route names from the plan
+4. Replace `PAGE1_LABEL`, etc. with display labels
+5. Replace `PAGE1_ICON_GLYPH`, etc. with glyphs from the Icon Lookup Table
+6. Add or remove `NavigationViewItem` + `TabBarItem` pairs as needed
+7. Both `NavigationViewItem` and `TabBarItem` for the same page MUST use the same `uen:Region.Name`

--- a/plugins/uno-platform-studio/skills/uno-navigation-routes/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-navigation-routes/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: uno-navigation-routes
+description: "Define and register navigation routes in Uno Platform applications using ViewMap, DataViewMap, ResultDataViewMap, and RouteMap."
+when_to_use: "Use when registering views and ViewModels for navigation, setting up `ViewMap`, `DataViewMap`, or `ResultDataViewMap`, configuring nested routes and route hierarchies, adding route dependencies or initialization logic, or understanding how routes map to navigation paths."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: navigation
+---
+
+# Uno Navigation Routes — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Routes Documentation
+
+```
+uno_platform_docs_search("Uno Navigation routes ViewMap DataViewMap RouteMap register")
+```
+
+Primary documentation pages:
+- **Define Routes**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRoutes.md`
+- **Register Routes**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/RegisterRoutes.md`
+
+Fetch the define routes page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRoutes.md")
+```
+
+### Step 2: For View-ViewModel Association
+
+Fetch the register routes page for binding views to view models:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/Walkthrough/RegisterRoutes.md")
+```
+
+### Step 3: For Data-Based and Result-Based Navigation
+
+If the user needs to pass data or get results via routes:
+
+```
+uno_platform_docs_search("Uno Navigation DataViewMap ResultDataViewMap data navigation result")
+```
+
+See also the `uno-navigation-data` skill.
+
+## Key Principles (Stable)
+
+- Routes are registered in `App.xaml.cs` via the `RegisterRoutes` method
+- `ViewMap` — associates a View with a ViewModel
+- `DataViewMap` — associates a View/ViewModel with a data type for data-based navigation
+- `ResultDataViewMap` — like DataViewMap but also defines a result type
+- `RouteMap` — defines a named route with nested child routes
+- Route names typically match the page name without the "Page" suffix
+
+## Related Skills
+
+- [[uno-navigation-setup]] — Initial navigation configuration
+- [[uno-navigation-data]] — Passing data during navigation
+- [[uno-navigation-code]] — Programmatic navigation using routes
+- [[uno-navigation-xaml]] — XAML-based navigation using route names

--- a/plugins/uno-platform-studio/skills/uno-navigation-setup/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-navigation-setup/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: uno-navigation-setup
+description: "Set up and configure Uno Platform Navigation Extensions in an application."
+when_to_use: "Use when creating a new Uno Platform project with navigation support, adding navigation to an existing Uno Platform app, configuring `UseNavigation` in App.xaml.cs host builder, setting up route registration, or understanding the relationship between Navigation and Toolkit packages."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: navigation
+---
+
+# Uno Navigation Setup — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Navigation Overview & Setup Documentation
+
+```
+uno_platform_docs_search("Uno Navigation Extensions setup configuration routes UseNavigation")
+```
+
+Primary documentation pages:
+- **Navigation Overview**: `external/uno.extensions/doc/Learn/Navigation/NavigationOverview.md`
+- **Define Routes**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRoutes.md`
+- **Register Routes**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/RegisterRoutes.md`
+
+Fetch the overview page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/NavigationOverview.md")
+```
+
+### Step 2: For Route Registration
+
+Fetch the route registration walkthrough:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRoutes.md")
+```
+
+### Step 3: For Host Builder Configuration
+
+If the user needs the App.xaml.cs setup:
+
+```
+uno_platform_docs_search("Uno Navigation host builder UseNavigation UseToolkitNavigation App.xaml.cs")
+```
+
+## Key Principles (Stable)
+
+- Add `Navigation` to `<UnoFeatures>`: `<UnoFeatures>Navigation;Toolkit</UnoFeatures>`
+- Adding `Toolkit` enables TabBar and NavigationBar controls with navigation support
+- Navigation is configured via the host builder in App.xaml.cs using `.UseNavigation()`
+- Routes are registered using `ViewMap`, `DataViewMap`, or `RouteMap`
+- The navigation host (`Shell.xaml`) is the root of the navigation hierarchy
+- Do NOT use `Region.Attached="True"` inside Shell.xaml or ExtendedSplashScreen content
+
+## Related Skills
+
+- [[uno-navigation-routes]] — Defining and registering routes
+- [[uno-navigation-regions]] — Region-based navigation
+- [[uno-navigation-code]] — Programmatic navigation
+- [[uno-navigation-xaml]] — Declarative XAML navigation

--- a/plugins/uno-platform-studio/skills/uno-navigation-tabbar/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-navigation-tabbar/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: uno-navigation-tabbar
+description: "Implement TabBar navigation in Uno Platform using region-based navigation. Provides complete, compilable shell template for bottom tab navigation. Use for 3-5 top-level pages in mobile-first apps."
+when_to_use: "Use when 3-5 top-level pages, mobile-first / consumer apps, default choice when prompt does not indicate desktop or enterprise, building bottom navigation (mobile), linking TabBar items to content pages via regions, or using TabBar with Navigation Extensions."
+metadata:
+  author: uno-platform
+  version: "3.5"
+  category: navigation
+---
+
+# Uno Navigation with TabBar — Agent Skill
+
+## Reference Templates
+
+For complete, compilable shell XAML with parameterized placeholders, see:
+
+**`references/shell-tabbar-template.md`** — Contains:
+- Icon lookup table (Home, Search, Settings, Profile, etc.)
+- SHELL_PAGE_NAME.xaml shell template with TabBar
+- Page template (XAML + code-behind)
+- Route registration template
+- Substitution rules
+- Localization template (Resources.resw)
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the TabBar Navigation Documentation
+
+```
+uno_platform_docs_search("Uno Navigation TabBar bottom tab region navigation")
+```
+
+Primary documentation pages:
+- **TabBar Navigation (Chefs)**: `external/uno.chefs/doc/toolkit/NavigateTabBar.md`
+- **Define Regions**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRegions.md`
+
+Fetch the Chefs TabBar page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.chefs/doc/toolkit/NavigateTabBar.md")
+```
+
+### Step 2: For TabBar Control Reference
+
+For TabBar control properties and styling:
+
+```
+uno_platform_docs_search("Uno Toolkit TabBar TabBarItem styles badges")
+```
+
+See also the `uno-toolkit-tabbar` skill for the control itself.
+
+### Step 3: For Responsive Navigation
+
+If combining TabBar (mobile) with NavigationView (desktop):
+
+See the `uno-navigation-responsive-shell` skill.
+
+## Key Principles (Stable)
+
+- TabBar uses region-based navigation similarly to NavigationView
+- Each `TabBarItem` gets `uen:Region.Name="RouteName"`
+- Parent container and content area need `Region.Attached="True"`
+- Apply `BottomTabBarStyle` to the `TabBar`; per-`TabBarItem` styling comes from the active design-theme (e.g., `MaterialBottomTabBarItemStyle` from [[uno-toolkit-material-theme]])
+- Requires `Toolkit` in `<UnoFeatures>` along with `Navigation`
+- XAML namespaces: `xmlns:uen="using:Uno.Extensions.Navigation.UI"` and `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Critical Rules
+
+- The root `Grid` with `uen:Region.Attached="True"` MUST be a direct child of the Page content — it enables region navigation
+- `uen:Region.Navigator="Visibility"` MUST be on the content area Grid — this tells the framework to toggle child visibility
+- **The content area Grid with `Region.Navigator="Visibility"` must be empty in XAML.** Do not add `Collapsed` child elements for each route. The navigation framework resolves registered routes and injects the corresponding views at runtime.
+- `uen:Region.Attached="True"` MUST also be on the TabBar itself
+- Route names in `RouteMap` MUST match the `uen:Region.Name` values in `SHELL_PAGE_NAME.xaml`
+- Tab page routes are nested under the `"Main"` route so only the content area updates, not the entire page
+- Do NOT use `Region.Attached="True"` inside `Shell.xaml` — only in `SHELL_PAGE_NAME.xaml`
+
+## Related Skills
+
+- [[uno-navigation-regions]] — Region concepts
+- [[uno-navigation-responsive-shell]] — Adaptive navigation
+- [[uno-navigation-panel-visibility]] — Visibility-based content switching details
+- [[uno-toolkit-tabbar]] — TabBar control reference
+- [[uno-navigation-navigationview]] — Sidebar navigation alternative
+- [[uno-navigation-routes]] — Route registration details

--- a/plugins/uno-platform-studio/skills/uno-navigation-tabbar/references/shell-tabbar-template.md
+++ b/plugins/uno-platform-studio/skills/uno-navigation-tabbar/references/shell-tabbar-template.md
@@ -1,0 +1,186 @@
+# Shell: Bottom TabBar — Reference Templates
+
+Ready-to-use templates for a bottom TabBar navigation shell. Copy, substitute placeholders, and use.
+
+## Icon Lookup Table
+
+| Page Concept | Glyph | Unicode |
+|---|---|---|
+| Home / Dashboard | `&#xE80F;` | `\uE80F` |
+| Search / Explore | `&#xE721;` | `\uE721` |
+| Settings / Gear | `&#xE713;` | `\uE713` |
+| Profile / Person | `&#xE77B;` | `\uE77B` |
+| Favorites / Heart | `&#xE734;` | `\uE734` |
+| Add / Plus | `&#xE710;` | `\uE710` |
+| List / Bullets | `&#xE8FD;` | `\uE8FD` |
+| Chart / Analytics | `&#xE9D9;` | `\uE9D9` |
+| Calendar / Date | `&#xE787;` | `\uE787` |
+| Mail / Messages | `&#xE715;` | `\uE715` |
+| Cart / Shopping | `&#xE7BF;` | `\uE7BF` |
+| Notification / Bell | `&#xEA8F;` | `\uEA8F` |
+
+## Required XAML Namespaces
+
+```xml
+xmlns:uen="using:Uno.Extensions.Navigation.UI"
+xmlns:utu="using:Uno.Toolkit.UI"
+```
+
+## SHELL_PAGE_NAME.xaml (Shell)
+
+The content area Grid with `Region.Navigator="Visibility"` must be **empty** — the navigation framework injects views at runtime from registered routes.
+
+```xml
+<Page x:Class="SHELL_PAGE_CLASS"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:uen="using:Uno.Extensions.Navigation.UI"
+      xmlns:utu="using:Uno.Toolkit.UI"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <Grid uen:Region.Attached="True">
+            <Grid.RowDefinitions>
+                <RowDefinition />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <!-- Content area: visibility-based region switching (empty — framework injects views) -->
+            <Grid Grid.Row="0"
+                  uen:Region.Attached="True"
+                  uen:Region.Navigator="Visibility" />
+
+            <!-- Bottom TabBar -->
+            <utu:TabBar Grid.Row="1"
+                        uen:Region.Attached="True"
+                        Style="{StaticResource BottomTabBarStyle}">
+                <!-- REPLACE: One TabBarItem per Tab page -->
+                <utu:TabBarItem uen:Region.Name="PAGE1_NAME"
+                                Content="PAGE1_LABEL"
+                                Style="{StaticResource MaterialBottomTabBarItemStyle}">
+                    <utu:TabBarItem.Icon>
+                        <FontIcon Glyph="PAGE1_ICON_GLYPH" />
+                    </utu:TabBarItem.Icon>
+                </utu:TabBarItem>
+                <utu:TabBarItem uen:Region.Name="PAGE2_NAME"
+                                Content="PAGE2_LABEL"
+                                Style="{StaticResource MaterialBottomTabBarItemStyle}">
+                    <utu:TabBarItem.Icon>
+                        <FontIcon Glyph="PAGE2_ICON_GLYPH" />
+                    </utu:TabBarItem.Icon>
+                </utu:TabBarItem>
+                <utu:TabBarItem uen:Region.Name="PAGE3_NAME"
+                                Content="PAGE3_LABEL"
+                                Style="{StaticResource MaterialBottomTabBarItemStyle}">
+                    <utu:TabBarItem.Icon>
+                        <FontIcon Glyph="PAGE3_ICON_GLYPH" />
+                    </utu:TabBarItem.Icon>
+                </utu:TabBarItem>
+            </utu:TabBar>
+        </Grid>
+    </Grid>
+</Page>
+```
+
+## Page Template (PageName.xaml)
+
+Create one `.xaml` + `.xaml.cs` pair per page in the appropriate project folder.
+
+```xml
+<Page x:Class="PAGE_CLASS"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <TextBlock Text="PAGE_NAME"
+                   FontSize="24"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center" />
+    </Grid>
+</Page>
+```
+
+## Page Template (PageName.xaml.cs)
+
+```csharp
+namespace PAGE_NAMESPACE;
+
+public sealed partial class PAGE_NAMEPage : Page
+{
+    public PAGE_NAMEPage()
+    {
+        this.InitializeComponent();
+    }
+}
+```
+
+## Route Registration (App.xaml.cs)
+
+```csharp
+private static void RegisterRoutes(IViewRegistry views, IRouteRegistry routes)
+{
+    views.Register(
+        new ViewMap(ViewModel: typeof(ShellModel)),
+        new ViewMap<SHELL_PAGE_NAME>(),
+        // REPLACE: One ViewMap per page
+        new ViewMap<PAGE1_NAMEPage>(),
+        new ViewMap<PAGE2_NAMEPage>(),
+        new ViewMap<PAGE3_NAMEPage>()
+    );
+
+    routes.Register(
+        new RouteMap("", View: views.FindByViewModel<ShellModel>(),
+            Nested:
+            [
+                new RouteMap("Main", View: views.FindByView<SHELL_PAGE_NAME>(),
+                    IsDefault: true,
+                    Nested:
+                    [
+                        // REPLACE: One RouteMap per Tab page
+                        new RouteMap("PAGE1_NAME", View: views.FindByView<PAGE1_NAMEPage>(), IsDefault: true),
+                        new RouteMap("PAGE2_NAME", View: views.FindByView<PAGE2_NAMEPage>()),
+                        new RouteMap("PAGE3_NAME", View: views.FindByView<PAGE3_NAMEPage>())
+                    ]
+                )
+            ]
+        )
+    );
+}
+```
+
+## Substitution Rules
+
+1. Replace `SHELL_PAGE_CLASS` with the full `x:Class` value for the shell page (e.g., `MyApp.Presentation.MainPage`)
+2. Replace `SHELL_PAGE_NAME` with the class name of the shell page (e.g., `MainPage`). This is the page that hosts the TabBar navigation chrome.
+3. Replace `PAGE_CLASS` with the full `x:Class` value for each content page (e.g., `MyApp.Presentation.HomePage`)
+4. Replace `PAGE_NAMESPACE` with the namespace for content pages (e.g., `MyApp.Presentation`)
+5. Replace `PAGE1_NAME`, `PAGE2_NAME`, `PAGE3_NAME` with route names from the plan (e.g., `Home`, `Search`, `Profile`)
+6. Replace `PAGE1_LABEL`, `PAGE2_LABEL`, `PAGE3_LABEL` with display labels (or use `x:Uid` for localization)
+7. Replace `PAGE1_ICON_GLYPH`, etc. with glyphs from the Icon Lookup Table above (e.g., `&#xE80F;`)
+8. Add or remove `TabBarItem` entries to match the number of Tab pages in the plan
+9. The `BottomTabBarStyle` goes on the `TabBar` container; `MaterialBottomTabBarItemStyle` goes on each `TabBarItem`
+
+## Route Registration Rules
+
+1. Route names (first argument to `RouteMap`) MUST match the `uen:Region.Name` values in `SHELL_PAGE_NAME.xaml`
+2. Tab page routes are nested under the `"Main"` route so only the content area updates, not the entire page
+3. The empty string `""` route is the root shell route
+4. `ViewMap` entries without a ViewModel are valid
+
+## Localization Template (Strings/en/Resources.resw)
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="PAGE1_NAME_Tab.Content" xml:space="preserve">
+    <value>PAGE1_LABEL</value>
+  </data>
+  <data name="PAGE1_NAME_Tab.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>PAGE1_LABEL tab</value>
+  </data>
+  <!-- Repeat for each tab -->
+</root>
+```
+
+When using `x:Uid`, set `x:Uid="PAGE1_NAME_Tab"` on the `TabBarItem` instead of `Content="PAGE1_LABEL"`.

--- a/plugins/uno-platform-studio/skills/uno-navigation-troubleshooting/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-navigation-troubleshooting/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: uno-navigation-troubleshooting
+description: "Troubleshoot common issues with Uno Platform Navigation Extensions."
+when_to_use: "Use when navigation is not working or throwing errors, pages not loading or blank screens, back navigation not working as expected, region-based navigation issues, route registration errors, or shell.xaml / ExtendedSplashScreen initialization issues."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: navigation
+---
+
+# Uno Navigation Troubleshooting — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Search for Navigation Troubleshooting
+
+```
+uno_platform_docs_search("Uno Navigation troubleshooting errors common issues")
+```
+
+### Step 2: Check Common Pitfalls
+
+Fetch the regions how-to page for critical warnings:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/HowTo-Regions.md")
+```
+
+### Step 3: For Route Registration Issues
+
+```
+uno_platform_docs_search("Uno Navigation route not found register ViewMap DataViewMap")
+```
+
+### Step 4: For Advanced Navigation Issues
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/Advanced/HowTo-AdvancedPageNavigation.md")
+```
+
+## Common Issues (Stable Reference)
+
+1. **Region.Attached in Shell.xaml**: NEVER use `Region.Attached="True"` inside Shell.xaml or ExtendedSplashScreen content — navigation host isn't ready yet
+2. **Missing route registration**: All pages must be registered via `ViewMap`/`DataViewMap` in `RegisterRoutes`
+3. **Missing UnoFeatures**: Ensure `Navigation;Toolkit` are in `<UnoFeatures>`
+4. **Missing XAML namespace**: `xmlns:uen="using:Uno.Extensions.Navigation.UI"` required for regions and attached properties
+5. **Back stack issues**: Use qualifiers (`-/` or `Qualifiers.ClearBackStack`) to manage back stack
+6. **Data not arriving**: Ensure `DataViewMap` is registered for the data type, and ViewModel accepts data via constructor
+
+## Related Skills
+
+- [[uno-navigation-setup]] — Proper setup
+- [[uno-navigation-regions]] — Region configuration
+- [[uno-navigation-routes]] — Route registration

--- a/plugins/uno-platform-studio/skills/uno-navigation-xaml/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-navigation-xaml/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: uno-navigation-xaml
+description: "Implement declarative navigation in Uno Platform XAML using Navigation.Request and Navigation.Data attached properties."
+when_to_use: "Use when adding navigation to buttons, list items, or controls directly in XAML, navigation without writing code-behind, using `uen:Navigation.Request` attached property for route-based navigation, passing data via `uen:Navigation.Data` in XAML, navigation from `ItemsRepeater` or `ListView` item clicks/selections, or simple Frame shell: 1-2 pages, navigation is secondary, no TabBar or NavigationView needed."
+metadata:
+  author: uno-platform
+  version: "3.3"
+  category: navigation
+---
+
+# Uno Navigation via XAML — Agent Skill
+
+## Reference Templates
+
+For a complete, compilable Frame-based shell with parameterized placeholders, see:
+
+**`references/shell-frame-template.md`** — Contains:
+- SHELL_PAGE_NAME.xaml shell template
+- Navigation.Request syntax reference
+- Page template (XAML + code-behind)
+- Route registration template
+- Substitution rules
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the XAML Navigation Documentation
+
+```
+uno_platform_docs_search("Uno Navigation XAML Navigation.Request Navigation.Data attached properties declarative")
+```
+
+Primary documentation pages:
+- **Navigate Using Attached Properties in XAML**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/NavigateUsingAttachedPropertiesInXAML.md`
+- **XAML Navigation in Chefs**: `external/uno.chefs/doc/navigation/XamlNavigation.md`
+- **Navigation Overview (XAML section)**: `external/uno.extensions/doc/Learn/Navigation/NavigationOverview.md`
+
+Fetch the main walkthrough:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/Walkthrough/NavigateUsingAttachedPropertiesInXAML.md")
+```
+
+### Step 2: For Chefs App Examples
+
+For real-world XAML navigation patterns:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.chefs/doc/navigation/XamlNavigation.md")
+```
+
+### Step 3: For Qualifiers in XAML
+
+If the user needs back-stack manipulation in XAML (like `-/` to clear):
+
+See the `uno-navigation-qualifiers` skill.
+
+## Key Principles (Stable)
+
+- XAML namespace: `xmlns:uen="using:Uno.Extensions.Navigation.UI"`
+- `uen:Navigation.Request="RouteName"` triggers navigation on interaction (click/tap)
+- `uen:Navigation.Data="{Binding SomeData}"` passes data with the navigation request
+- Works on Button, ListView, ItemsRepeater, and other interactive controls
+- No Click event handler or code-behind needed
+- Supports qualifier prefixes in the route string (e.g., `-/Login` to clear back stack)
+
+## Navigation.Request Syntax
+
+- **Navigate forward**: `uen:Navigation.Request="PageName"` — pushes page onto the frame stack
+- **Navigate and clear back stack**: `uen:Navigation.Request="-/PageName"` — replaces the current page
+- **Navigate back**: `uen:Navigation.Request="!back"` — pops the current page
+- **Navigate to nested region**: `uen:Navigation.Request="./RegionName"` — for visibility-based regions
+
+## Critical Rules
+
+- `uen:Navigation.Request` is an attached property — it works on any UI element that supports `Click` or `Tapped`
+- Navigation happens via XAML only — no code-behind `INavigator` calls needed for simple transitions
+- The `!back` request navigates back in the frame stack
+- The `-/` prefix clears the back stack (use for login-to-home transitions)
+- Route names in `RouteMap` MUST match the `uen:Navigation.Request` values used in XAML
+- Do NOT use `Region.Attached="True"` inside `Shell.xaml` — only in `SHELL_PAGE_NAME.xaml`
+- On secondary pages, always include a back button with `uen:Navigation.Request="!back"`
+
+## Related Skills
+
+- [[uno-navigation-code]] — Programmatic navigation alternative
+- [[uno-navigation-qualifiers]] — Qualifier prefixes
+- [[uno-navigation-routes]] — Route registration
+- [[uno-navigation-data]] — Data passing patterns
+- [[uno-navigation-tabbar]] — Alternative: bottom tab navigation for 3-5 pages
+- [[uno-navigation-navigationview]] — Alternative: sidebar navigation for desktop

--- a/plugins/uno-platform-studio/skills/uno-navigation-xaml/references/shell-frame-template.md
+++ b/plugins/uno-platform-studio/skills/uno-navigation-xaml/references/shell-frame-template.md
@@ -1,0 +1,128 @@
+# Shell: Simple Frame — Reference Templates
+
+Ready-to-use templates for a simple Frame-based navigation shell. Copy, substitute placeholders, and use.
+
+## SHELL_PAGE_NAME.xaml (Shell)
+
+```xml
+<Page x:Class="SHELL_PAGE_CLASS"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:uen="using:Uno.Extensions.Navigation.UI"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <!-- REPLACE: Build your main page content here -->
+        <!-- Use uen:Navigation.Request on buttons to navigate to other pages -->
+        <StackPanel HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Spacing="16">
+            <TextBlock Text="APP_TITLE"
+                       FontSize="32"
+                       HorizontalAlignment="Center" />
+            <!-- REPLACE: One button per navigable page -->
+            <Button Content="Go to PAGE2_LABEL"
+                    HorizontalAlignment="Center"
+                    uen:Navigation.Request="PAGE2_NAME" />
+        </StackPanel>
+    </Grid>
+</Page>
+```
+
+## Navigation.Request Syntax
+
+- **Navigate forward**: `uen:Navigation.Request="PageName"` — pushes page onto the frame stack
+- **Navigate and clear back stack**: `uen:Navigation.Request="-/PageName"` — replaces the current page
+- **Navigate back**: `uen:Navigation.Request="!back"` — pops the current page
+- **Navigate to nested region**: `uen:Navigation.Request="./RegionName"` — for visibility-based regions
+
+## Page Template (PageName.xaml)
+
+Create one `.xaml` + `.xaml.cs` pair per page in the appropriate project folder.
+
+```xml
+<Page x:Class="PAGE_CLASS"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:uen="using:Uno.Extensions.Navigation.UI"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition />
+        </Grid.RowDefinitions>
+
+        <!-- Top bar with back button -->
+        <Button Content="Back"
+                uen:Navigation.Request="!back"
+                Margin="8" />
+
+        <!-- REPLACE: Page content goes here -->
+        <Grid Grid.Row="1">
+            <TextBlock Text="PAGE_NAME"
+                       FontSize="24"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center" />
+        </Grid>
+    </Grid>
+</Page>
+```
+
+## Page Template (PageName.xaml.cs)
+
+```csharp
+namespace PAGE_NAMESPACE;
+
+public sealed partial class PAGE_NAMEPage : Page
+{
+    public PAGE_NAMEPage()
+    {
+        this.InitializeComponent();
+    }
+}
+```
+
+## Route Registration (App.xaml.cs)
+
+Add to the existing `RegisterRoutes` method:
+
+```csharp
+private static void RegisterRoutes(IViewRegistry views, IRouteRegistry routes)
+{
+    views.Register(
+        new ViewMap(ViewModel: typeof(ShellModel)),
+        new ViewMap<SHELL_PAGE_NAME>(),
+        // REPLACE: One ViewMap per page
+        new ViewMap<PAGE2_NAMEPage>()
+    );
+
+    routes.Register(
+        new RouteMap("", View: views.FindByViewModel<ShellModel>(),
+            Nested:
+            [
+                new RouteMap("Main", View: views.FindByView<SHELL_PAGE_NAME>(),
+                    IsDefault: true,
+                    Nested:
+                    [
+                        // REPLACE: One RouteMap per secondary page
+                        new RouteMap("PAGE2_NAME", View: views.FindByView<PAGE2_NAMEPage>())
+                    ]
+                )
+            ]
+        )
+    );
+}
+```
+
+## Substitution Rules
+
+1. Replace `SHELL_PAGE_CLASS` with the full `x:Class` value for the shell page (e.g., `MyApp.Presentation.MainPage`)
+2. Replace `SHELL_PAGE_NAME` with the class name of the shell page (e.g., `MainPage`). This is the page that hosts the primary navigation content.
+3. Replace `PAGE_CLASS` with the full `x:Class` value for each content page (e.g., `MyApp.Presentation.DetailPage`)
+4. Replace `PAGE_NAMESPACE` with the namespace for content pages (e.g., `MyApp.Presentation`)
+5. Replace `APP_TITLE` with the app name from the plan
+6. Replace `PAGE2_NAME` with the route name of the secondary page (e.g., `Detail`)
+7. Replace `PAGE2_LABEL` with the display label (e.g., `"View Details"`)
+8. Add more `Button` + `Navigation.Request` pairs for additional pages
+9. On secondary pages, always include a back button with `uen:Navigation.Request="!back"`

--- a/plugins/uno-platform-studio/skills/uno-testing-assertions/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-testing-assertions/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 # Uno Platform Test Assertions Skill
 
-> **Prerequisite:** This skill requires the **Uno App MCP** (the `uno_app_*` tools), provided by the Uno tooling / Uno Platform Dev Server. It is a separate server from the documentation MCP used by other skills. Before proceeding, confirm the `uno_app_*` tools are available; if they are not, stop and tell the user to enable the Uno tooling rather than attempting to test without them.
+> **Prerequisite:** This skill requires the **Uno App MCP** (the `uno_app_*` tools), provided by the Uno tooling. It is a separate server from the documentation MCP used by other skills. Before proceeding, confirm the `uno_app_*` tools are available; if they are not, stop and tell the user to enable the Uno tooling rather than attempting to test without them.
 
 This skill provides patterns for validating UI state and asserting test conditions when testing Uno Platform applications with the Uno App MCP tools.
 

--- a/plugins/uno-platform-studio/skills/uno-testing-assertions/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-testing-assertions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uno-testing-assertions
-description: "Provides assertion and validation patterns for UI testing of Uno Platform applications."
+description: "Provides assertion and validation patterns for UI testing of Uno Platform applications with the Uno App MCP server tools."
 when_to_use: "Use this skill when you need to validate UI state, verify element properties, compare screenshots, or assert on data binding values during automated testing. Complements the ui-testing skill with validation-specific guidance."
 compatibility: Requires the Uno App MCP server to be configured. Use alongside the ui-testing skill for complete test coverage.
 metadata:
@@ -10,6 +10,8 @@ metadata:
 ---
 
 # Uno Platform Test Assertions Skill
+
+> **Prerequisite:** This skill requires the **Uno App MCP** (the `uno_app_*` tools), provided by the Uno tooling / Uno Platform Dev Server. It is a separate server from the documentation MCP used by other skills. Before proceeding, confirm the `uno_app_*` tools are available; if they are not, stop and tell the user to enable the Uno tooling rather than attempting to test without them.
 
 This skill provides patterns for validating UI state and asserting test conditions when testing Uno Platform applications with the Uno App MCP tools.
 

--- a/plugins/uno-platform-studio/skills/uno-testing-assertions/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-testing-assertions/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: uno-testing-assertions
+description: "Provides assertion and validation patterns for UI testing of Uno Platform applications."
+when_to_use: "Use this skill when you need to validate UI state, verify element properties, compare screenshots, or assert on data binding values during automated testing. Complements the ui-testing skill with validation-specific guidance."
+compatibility: Requires the Uno App MCP server to be configured. Use alongside the ui-testing skill for complete test coverage.
+metadata:
+  author: uno-platform
+  version: "1.3"
+  category: testing
+---
+
+# Uno Platform Test Assertions Skill
+
+This skill provides patterns for validating UI state and asserting test conditions when testing Uno Platform applications with the Uno App MCP tools.
+
+## Assertion Types
+
+### Visual Assertions (Screenshots)
+
+Use `uno_app_get_screenshot` to capture visual state:
+
+```
+uno_app_get_screenshot(fileType: "png", quality: 100, path: "/path/to/screenshot.png")
+```
+
+**Validation approaches:**
+1. **Visual comparison**: Compare with baseline images
+2. **Manual review**: Save screenshots for human inspection
+3. **AI-assisted validation**: Describe expected visual state and verify
+
+### Structure Assertions (Visual Tree)
+
+Use `uno_app_visualtree_snapshot` to verify UI structure:
+
+**Assert element exists:**
+- Get visual tree snapshot
+- Search for element by name, AutomationId, or type
+- Fail if element not found
+
+**Assert element not visible:**
+- Get tree with `includeHidden: false`
+- Verify element is NOT in the returned tree
+
+**Assert element visible:**
+- Get tree with `includeHidden: false`
+- Verify element IS in the returned tree
+
+### Property Assertions
+
+From visual tree, check element properties:
+
+| Property | What to Check |
+|----------|---------------|
+| `IsEnabled` | Element can be interacted with |
+| `IsChecked` | Checkbox/Toggle state |
+| `Content` | Button/Label text |
+| `Text` | TextBox/TextBlock content |
+| `SelectedIndex` | ComboBox/List selection |
+| `Value` | Slider/ProgressBar value |
+
+### Data Assertions
+
+Use `uno_app_get_element_datacontext` to validate bound data:
+
+```
+uno_app_get_element_datacontext(elementRef: "element_handle")
+```
+
+Verify:
+- ViewModel property values
+- Collection counts and items
+- Computed properties
+- State flags
+
+## Common Assertion Patterns
+
+### Assert Page Loaded
+
+```
+1. uno_app_visualtree_snapshot(justMyCode: true)
+2. Search for expected page/view element
+3. Verify page-specific elements exist
+4. Optionally capture screenshot for visual confirmation
+```
+
+### Assert Button State
+
+```
+1. uno_app_visualtree_snapshot(justMyCode: true)
+2. Find button by name or AutomationId
+3. Check IsEnabled property
+4. Verify Content matches expected text
+```
+
+### Assert Text Content
+
+```
+1. uno_app_visualtree_snapshot(justMyCode: true)
+2. Find TextBlock/TextBox element
+3. Verify Text property matches expected value
+```
+
+### Assert List Items
+
+```
+1. uno_app_visualtree_snapshot(justMyCode: true)
+2. Find ListView/ItemsRepeater element
+3. Count child items
+4. Verify expected count
+5. Check item content if needed
+```
+
+### Assert Dialog Displayed
+
+```
+1. uno_app_visualtree_snapshot(justMyCode: true)
+2. Search for ContentDialog or Popup element
+3. Verify dialog-specific content exists
+4. Capture screenshot for visual confirmation
+```
+
+### Assert Form Validation Errors
+
+```
+1. Enter invalid data in form
+2. Attempt to submit
+3. uno_app_visualtree_snapshot(justMyCode: true)
+4. Look for validation error TextBlocks
+5. Verify error messages match expected text
+```
+
+### Assert Navigation Occurred
+
+```
+1. Trigger navigation action
+2. uno_app_visualtree_snapshot(justMyCode: true)
+3. Verify previous page elements are gone
+4. Verify new page elements are present
+```
+
+## Screenshot-Based Assertions
+
+### Capturing for Comparison
+
+```
+uno_app_get_screenshot(
+  fileType: "png",
+  quality: 100,
+  path: "/tests/screenshots/test_case_name.png"
+)
+```
+
+### Assertion Strategies
+
+**Pixel-perfect comparison:**
+- Use when UI is deterministic
+- Be aware of anti-aliasing differences
+- May need tolerance threshold
+
+**Region comparison:**
+- Compare specific areas of interest
+- Ignore dynamic content regions
+- Focus on stable UI elements
+
+**Semantic comparison:**
+- Describe what should be visible
+- Verify key visual elements
+- Allow for minor variations
+
+### Handling Dynamic Content
+
+When screenshots contain dynamic data:
+1. Use data mocking/seeding
+2. Focus assertions on static elements
+3. Mask dynamic regions
+4. Use structural validation instead
+
+## Data Context Assertions
+
+### Verify ViewModel State
+
+```
+1. Get element handle from visual tree
+2. uno_app_get_element_datacontext(elementRef: "handle")
+3. Parse returned XML
+4. Assert property values match expected state
+```
+
+### Example Assertions
+
+**Assert user is logged in:**
+- Get DataContext of user info element
+- Verify `IsLoggedIn: true`
+- Verify `Username` has value
+
+**Assert item count:**
+- Get DataContext with collection property
+- Verify collection count matches expected
+
+**Assert computed state:**
+- Get DataContext after action
+- Verify derived/computed properties updated
+
+## Timing and Retry Patterns
+
+### Wait for Condition
+
+When UI updates asynchronously:
+
+```
+Loop (max N attempts):
+  1. Get visual tree snapshot
+  2. Check for expected condition
+  3. If condition met, break
+  4. Wait brief interval
+  5. Retry
+Fail if condition not met after all attempts
+```
+
+### Wait for Element
+
+```
+Retry up to 10 times:
+  1. uno_app_visualtree_snapshot(justMyCode: true)
+  2. Search for expected element
+  3. If found, return success
+  4. Wait 500ms
+  5. Retry
+Fail with "Element not found" if all retries exhausted
+```
+
+### Wait for Loading Complete
+
+```
+Retry until no loading indicators:
+  1. uno_app_visualtree_snapshot(justMyCode: true)
+  2. Search for ProgressRing, ProgressBar, loading text
+  3. If none found, loading complete
+  4. Wait 500ms
+  5. Retry
+```
+
+## Failure Handling
+
+### Capture Diagnostic Info
+
+On assertion failure:
+1. Capture screenshot for visual debugging
+2. Get full visual tree (justMyCode: false)
+3. Log expected vs actual values
+4. Save DataContext if relevant
+
+### Common Failure Causes
+
+| Failure | Likely Cause | Resolution |
+|---------|--------------|------------|
+| Element not found | Timing issue | Add retry/wait |
+| Wrong property value | State not updated | Wait for async complete |
+| Screenshot mismatch | Dynamic content | Use data seeding or masking |
+| Stale handle | Tree changed | Refresh visual tree |
+
+## Test Organization Tips
+
+### Before Each Test
+1. Ensure app is running: `uno_app_get_runtime_info`
+2. Navigate to known initial state
+3. Clear any persistent test data
+
+### After Each Test
+1. Capture final screenshot (pass or fail)
+2. Reset app state if possible
+3. Log assertion results
+
+### On Failure
+1. Capture diagnostic screenshot
+2. Dump visual tree
+3. Save DataContext of relevant elements
+4. Preserve failure artifacts for debugging
+
+## Best Practices
+
+1. **Be specific**: Assert on exact values, not just existence
+2. **Use proper identifiers**: Rely on AutomationId over generated names
+3. **Handle timing**: Always account for async operations
+4. **Capture evidence**: Screenshots on both pass and fail
+5. **Test independence**: Each test should set up its own state
+6. **Meaningful messages**: Include context in failure messages

--- a/plugins/uno-platform-studio/skills/uno-testing-ui/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-testing-ui/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: uno-testing-ui
+description: "Automates UI testing for Uno Platform applications using the Uno App MCP server tools."
+when_to_use: "Use this skill when performing automated UI testing, visual validation, interaction testing, or end-to-end testing of Uno Platform cross-platform applications. Covers app lifecycle management, visual tree inspection, element interaction, screenshot capture, and test assertions."
+compatibility: Requires the Uno App MCP server to be configured and available. Works with Uno Platform applications targeting desktop (Windows, macOS, Linux), WebAssembly, iOS, and Android.
+metadata:
+  author: uno-platform
+  version: "1.3"
+  category: testing
+---
+
+# Uno Platform UI Testing Agent Skill
+
+This skill enables automated UI testing of Uno Platform applications using the Uno App MCP server tools. It provides comprehensive guidance for launching apps, inspecting UI elements, simulating user interactions, and validating visual output.
+
+## Overview
+
+The Uno App MCP server exposes a set of tools that allow agents to:
+- Start and stop Uno Platform applications
+- Capture screenshots for visual validation
+- Inspect the visual tree to discover UI elements
+- Interact with elements using automation peers
+- Simulate keyboard and pointer input
+- Retrieve element data context for state validation
+
+## Prerequisites
+
+1. The Uno App MCP server must be configured in your environment
+2. The target application must be an Uno Platform project with MCP client integration
+3. The project must have valid target frameworks (e.g., `net9.0-desktop`, `net9.0-browserwasm`)
+
+## Quick Start Workflow
+
+For most UI testing scenarios, follow this workflow:
+
+1. **Start the app** → `uno_app_start`
+2. **Verify app is running** → `uno_app_get_runtime_info`
+3. **Capture initial screenshot** → `uno_app_get_screenshot`
+4. **Get visual tree** → `uno_app_visualtree_snapshot`
+5. **Interact with elements** → `uno_app_element_peer_default_action` or input tools
+6. **Validate results** → Screenshots + visual tree inspection
+7. **Close the app** → `uno_app_close`
+
+## Available MCP Tools
+
+### App Lifecycle Tools
+
+| Tool | Description |
+|------|-------------|
+| `uno_app_start` | Starts the application in debug mode with Hot Reload |
+| `uno_app_get_runtime_info` | Gets runtime info (PID, window title, platform, uptime) |
+| `uno_app_close` | Terminates the running application (desktop only) |
+
+### Visual Inspection Tools
+
+| Tool | Description |
+|------|-------------|
+| `uno_app_get_screenshot` | Captures a screenshot for visual validation |
+| `uno_app_visualtree_snapshot` | Gets XML visual tree snapshot with element handles |
+| `uno_app_get_element_datacontext` | Gets the DataContext of a specific element |
+
+### Interaction Tools
+
+| Tool | Description |
+|------|-------------|
+| `uno_app_element_peer_default_action` | Invokes the default automation action on an element |
+| `uno_app_element_peer_action` | Invokes a specific automation peer action |
+| `uno_app_pointer_click` | Performs pointer click at coordinates |
+| `uno_app_key_press` | Presses a keyboard key |
+| `uno_app_type_text` | Types text using keyboard simulation |
+
+### Diagnostic Tools
+
+| Tool | Description |
+|------|-------------|
+| `uno_app_get_memory_counters` | Gets memory diagnostics for the running app |
+
+## Detailed Tool Usage
+
+### Starting an Application
+
+Use `uno_app_start` to launch the application:
+
+```
+Tool: uno_app_start
+Parameters:
+  - projectPath: Full path to the .csproj file (must be within MCP working directory)
+  - targetFramework: Target framework moniker (e.g., "net9.0-desktop", "net9.0-browserwasm")
+  - args: Optional command-line arguments (array)
+```
+
+**Example scenarios:**
+- Desktop testing: `targetFramework = "net9.0-desktop"`
+- WebAssembly testing: `targetFramework = "net9.0-browserwasm"`
+
+**Important:** Always verify the app started successfully by calling `uno_app_get_runtime_info` afterward.
+
+### Inspecting the Visual Tree
+
+Use `uno_app_visualtree_snapshot` to get an XML representation of the UI:
+
+```
+Tool: uno_app_visualtree_snapshot
+Parameters:
+  - justMyCode: Filter to user-defined elements only (default: true)
+  - includeBounds: Include element bounds for coordinate-based interaction (default: false)
+  - includeHidden: Include hidden/collapsed elements (default: false)
+```
+
+The returned XML contains element handles (refs) that can be used with interaction tools. Each element includes:
+- Element type and name
+- Automation properties
+- Handle/reference for interactions
+- Bounds (if requested)
+
+**Tip:** Set `justMyCode: true` to reduce noise from framework elements and focus on application UI.
+
+### Interacting with Elements
+
+**Preferred approach:** Use automation peers when element handles are available.
+
+1. **Default Action** (most common):
+   ```
+   Tool: uno_app_element_peer_default_action
+   Parameters:
+     - elementRef: Handle from visual tree snapshot
+   ```
+   This invokes the natural action (click for buttons, toggle for checkboxes, etc.)
+
+2. **Specific Action** (for advanced scenarios):
+   ```
+   Tool: uno_app_element_peer_action
+   Parameters:
+     - elementRef: Handle from visual tree snapshot
+     - action: Specific automation action name
+     - actionParameters: Optional parameters array
+   ```
+
+**Fallback approach:** Use coordinate-based input when handles aren't suitable.
+
+3. **Pointer Click**:
+   ```
+   Tool: uno_app_pointer_click
+   Parameters:
+     - x: Absolute physical X coordinate
+     - y: Absolute physical Y coordinate
+     - button: "left", "middle", or "right"
+     - clickCount: Number of clicks (default: 1)
+     - delayBetweenPresseAndReleaseInMs: Delay in milliseconds (default: 10)
+   ```
+
+4. **Keyboard Input**:
+   ```
+   Tool: uno_app_key_press
+   Parameters:
+     - virtualKey: VirtualKey name (e.g., "Enter", "Tab", "A")
+     - virtualKeyModifiers: Optional modifiers ("control", "shift", "menu", "windows")
+     - unicodeKey: Optional explicit unicode character
+   ```
+
+5. **Text Entry**:
+   ```
+   Tool: uno_app_type_text
+   Parameters:
+     - text: String of text to type
+     - intervalInMs: Delay between key presses
+   ```
+
+### Capturing Screenshots
+
+Use `uno_app_get_screenshot` for visual validation:
+
+```
+Tool: uno_app_get_screenshot
+Parameters:
+  - fileType: "png" or "jpeg"
+  - quality: Image quality 1-100 (default: 75)
+  - path: Optional file path to save the screenshot
+```
+
+Screenshots are essential for:
+- Visual regression testing
+- Documenting test execution
+- Debugging failed tests
+- Validating layout and styling
+
+### Validating Element State
+
+Use `uno_app_get_element_datacontext` to inspect bound data:
+
+```
+Tool: uno_app_get_element_datacontext
+Parameters:
+  - elementRef: Handle from visual tree snapshot
+```
+
+Returns an XML representation of the element's DataContext, useful for verifying:
+- ViewModel state
+- Data binding correctness
+- Business logic results
+
+## Testing Patterns
+
+### Pattern 1: Simple Click Test
+
+1. Start the app
+2. Get visual tree snapshot
+3. Find the target button by name/type
+4. Call `uno_app_element_peer_default_action` with its handle
+5. Get new visual tree or screenshot
+6. Verify expected changes
+
+### Pattern 2: Form Input Test
+
+1. Start the app
+2. Navigate to the form (if needed)
+3. Get visual tree to find input fields
+4. For each field:
+   - Call `uno_app_element_peer_default_action` to focus
+   - Call `uno_app_type_text` to enter data
+5. Submit the form
+6. Validate results via screenshot or data context
+
+### Pattern 3: Navigation Test
+
+1. Start the app
+2. Get initial visual tree snapshot
+3. Trigger navigation (click nav button, etc.)
+4. Wait briefly for navigation to complete
+5. Get new visual tree snapshot
+6. Verify the expected page/view is displayed
+
+### Pattern 4: Visual Regression Test
+
+1. Start the app
+2. Navigate to target state
+3. Capture screenshot with `uno_app_get_screenshot`
+4. Compare with baseline image
+5. Report differences
+
+## Best Practices
+
+### Element Selection
+- **Prefer automation peers** over coordinate clicks for reliability
+- Use `justMyCode: true` to filter framework elements
+- Look for elements with `x:Name` or `AutomationProperties.AutomationId`
+
+### Test Stability
+- Always verify app is running with `uno_app_get_runtime_info` before testing
+- Add brief delays between rapid interactions if needed
+- Refresh visual tree after actions that change UI state
+
+### Assertions
+- Use screenshots for visual validation
+- Use `uno_app_get_element_datacontext` for data validation
+- Check visual tree for element presence/absence
+
+### Cleanup
+- Always call `uno_app_close` at the end of tests (desktop)
+- Handle test failures gracefully with cleanup
+
+## Troubleshooting
+
+### "No connected app instance"
+- The app hasn't started or has crashed
+- Call `uno_app_start` to launch the app
+- Check build output for errors
+
+### Element not found in visual tree
+- Element may be hidden/collapsed (try `includeHidden: true`)
+- Element may be dynamically created (refresh the tree)
+- Check if using correct framework filter
+
+### Interaction not working
+- Verify element handle is from latest tree snapshot
+- Check if element is enabled and visible
+- Try coordinate-based input as fallback
+
+### Screenshots are blank or incorrect
+- Ensure app window is visible and not minimized
+- Check for correct target framework
+- Verify app has finished rendering
+
+## References
+
+For detailed implementation patterns, see:
+- [references/INTERACTION-PATTERNS.md](references/INTERACTION-PATTERNS.md) - Detailed interaction examples
+- [references/VISUAL-TREE-GUIDE.md](references/VISUAL-TREE-GUIDE.md) - Visual tree inspection guide

--- a/plugins/uno-platform-studio/skills/uno-testing-ui/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-testing-ui/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 # Uno Platform UI Testing Agent Skill
 
-> **Prerequisite:** This skill requires the **Uno App MCP** (the `uno_app_*` tools), provided by the Uno tooling / Uno Platform Dev Server. It is a separate server from the documentation MCP used by other skills. Before proceeding, confirm the `uno_app_*` tools are available; if they are not, stop and tell the user to enable the Uno tooling rather than attempting to test without them.
+> **Prerequisite:** This skill requires the **Uno App MCP** (the `uno_app_*` tools), provided by the Uno tooling. It is a separate server from the documentation MCP used by other skills. Before proceeding, confirm the `uno_app_*` tools are available; if they are not, stop and tell the user to enable the Uno tooling rather than attempting to test without them.
 
 This skill enables automated UI testing of Uno Platform applications using the Uno App MCP server tools. It provides comprehensive guidance for launching apps, inspecting UI elements, simulating user interactions, and validating visual output.
 

--- a/plugins/uno-platform-studio/skills/uno-testing-ui/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-testing-ui/SKILL.md
@@ -11,6 +11,8 @@ metadata:
 
 # Uno Platform UI Testing Agent Skill
 
+> **Prerequisite:** This skill requires the **Uno App MCP** (the `uno_app_*` tools), provided by the Uno tooling / Uno Platform Dev Server. It is a separate server from the documentation MCP used by other skills. Before proceeding, confirm the `uno_app_*` tools are available; if they are not, stop and tell the user to enable the Uno tooling rather than attempting to test without them.
+
 This skill enables automated UI testing of Uno Platform applications using the Uno App MCP server tools. It provides comprehensive guidance for launching apps, inspecting UI elements, simulating user interactions, and validating visual output.
 
 ## Overview

--- a/plugins/uno-platform-studio/skills/uno-testing-ui/references/INTERACTION-PATTERNS.md
+++ b/plugins/uno-platform-studio/skills/uno-testing-ui/references/INTERACTION-PATTERNS.md
@@ -1,0 +1,265 @@
+# Interaction Patterns Reference
+
+This document provides detailed examples of common UI interaction patterns using the Uno App MCP tools.
+
+## Button Interactions
+
+### Clicking a Button by Handle
+
+The most reliable way to click a button:
+
+1. Get the visual tree:
+   ```
+   uno_app_visualtree_snapshot(justMyCode: true, includeBounds: false, includeHidden: false)
+   ```
+
+2. Parse the XML to find the button element. Example output:
+   ```xml
+   <Button x:Name="SubmitButton" handle="btn_001" Content="Submit" />
+   ```
+
+3. Invoke the default action:
+   ```
+   uno_app_element_peer_default_action(elementRef: "btn_001")
+   ```
+
+### Double-Click Scenarios
+
+For elements requiring double-click, use pointer click:
+
+```
+uno_app_pointer_click(x: 250, y: 100, button: "left", clickCount: 2, delayBetweenPresseAndReleaseInMs: 50)
+```
+
+## Text Input
+
+### Entering Text in a TextBox
+
+1. Find the TextBox in the visual tree
+2. Focus the element:
+   ```
+   uno_app_element_peer_default_action(elementRef: "textbox_handle")
+   ```
+3. Type the text:
+   ```
+   uno_app_type_text(text: "Hello World", intervalInMs: 50)
+   ```
+
+### Clearing a TextBox
+
+1. Focus the TextBox
+2. Select all text:
+   ```
+   uno_app_key_press(virtualKey: "A", virtualKeyModifiers: "control")
+   ```
+3. Delete:
+   ```
+   uno_app_key_press(virtualKey: "Delete")
+   ```
+
+### Entering Special Characters
+
+Use `unicodeKey` for characters not easily represented by virtual keys:
+
+```
+uno_app_key_press(virtualKey: "None", unicodeKey: "€")
+```
+
+## Keyboard Navigation
+
+### Tab Navigation
+
+Move focus between elements:
+```
+uno_app_key_press(virtualKey: "Tab")
+```
+
+Move backwards:
+```
+uno_app_key_press(virtualKey: "Tab", virtualKeyModifiers: "shift")
+```
+
+### Enter to Submit
+
+Press Enter on focused button or form:
+```
+uno_app_key_press(virtualKey: "Enter")
+```
+
+### Escape to Cancel
+
+Close dialogs or cancel operations:
+```
+uno_app_key_press(virtualKey: "Escape")
+```
+
+## List and Selection Interactions
+
+### Selecting an Item in a ListView
+
+1. Get the visual tree to find list items
+2. Use default action on the item:
+   ```
+   uno_app_element_peer_default_action(elementRef: "listitem_handle")
+   ```
+
+### Multi-Select with Ctrl+Click
+
+For lists that support multi-selection:
+
+1. Click first item normally
+2. For additional items:
+   ```
+   uno_app_pointer_click(x: 150, y: 200, button: "left")
+   ```
+
+### Keyboard List Navigation
+
+Navigate in lists using arrow keys:
+```
+uno_app_key_press(virtualKey: "Down")
+uno_app_key_press(virtualKey: "Up")
+```
+
+## ComboBox/Dropdown Interactions
+
+### Opening a ComboBox
+
+```
+uno_app_element_peer_default_action(elementRef: "combobox_handle")
+```
+
+### Selecting an Item
+
+After opening:
+1. Use arrow keys to navigate:
+   ```
+   uno_app_key_press(virtualKey: "Down")
+   ```
+2. Press Enter to select:
+   ```
+   uno_app_key_press(virtualKey: "Enter")
+   ```
+
+## Checkbox and ToggleSwitch
+
+### Toggling a Checkbox
+
+```
+uno_app_element_peer_default_action(elementRef: "checkbox_handle")
+```
+
+### Verifying State
+
+After toggling, get a new visual tree snapshot and check the element's state properties.
+
+## Slider Interactions
+
+### Using Keyboard
+
+1. Focus the slider
+2. Use arrow keys:
+   ```
+   uno_app_key_press(virtualKey: "Right")  // Increase
+   uno_app_key_press(virtualKey: "Left")   // Decrease
+   ```
+
+### Using Page Keys
+
+For larger jumps:
+```
+uno_app_key_press(virtualKey: "PageUp")
+uno_app_key_press(virtualKey: "PageDown")
+```
+
+## Dialog Handling
+
+### Detecting a Dialog
+
+Get the visual tree and look for:
+- `ContentDialog` elements
+- Popup or flyout containers
+- Modal overlay elements
+
+### Dismissing Dialogs
+
+Use the dialog's button handles or:
+```
+uno_app_key_press(virtualKey: "Escape")  // Cancel/Close
+uno_app_key_press(virtualKey: "Enter")   // Accept/OK
+```
+
+## Scroll Interactions
+
+### Scrolling with Mouse Wheel
+
+Not directly supported; use keyboard alternatives:
+```
+uno_app_key_press(virtualKey: "PageDown")  // Scroll down
+uno_app_key_press(virtualKey: "PageUp")    // Scroll up
+uno_app_key_press(virtualKey: "Home")      // Scroll to top
+uno_app_key_press(virtualKey: "End")       // Scroll to bottom
+```
+
+### Scrolling to Element
+
+If an element is off-screen, focusing it may scroll it into view:
+```
+uno_app_element_peer_default_action(elementRef: "offscreen_element_handle")
+```
+
+## Context Menu Interactions
+
+### Opening Context Menu
+
+```
+uno_app_pointer_click(x: 200, y: 150, button: "right", clickCount: 1)
+```
+
+### Selecting Menu Item
+
+After opening, get the visual tree to find menu items and use default action.
+
+## Drag and Drop
+
+### Basic Drag Operation
+
+Drag operations typically require:
+1. Mouse down at source
+2. Move to destination
+3. Mouse up
+
+This pattern is complex and may require coordinate-based interaction with careful timing. Consider testing drag-and-drop logic through unit tests where possible.
+
+## Timing and Synchronization
+
+### Waiting for UI Updates
+
+After actions that trigger async operations or animations:
+1. Get a fresh visual tree snapshot
+2. Check for expected state changes
+3. Retry if needed with brief delays
+
+### Handling Loading States
+
+Look for loading indicators in the visual tree:
+- Progress rings/bars
+- Disabled states on interactive elements
+- Loading text or placeholders
+
+Wait until these are no longer present before continuing.
+
+## Error Recovery
+
+### Element Not Responding
+
+1. Try refreshing the visual tree
+2. Verify element is still visible and enabled
+3. Try alternative interaction method (keyboard vs mouse)
+4. Check if a dialog or overlay is blocking
+
+### Unexpected State
+
+1. Capture screenshot for debugging
+2. Get visual tree for analysis
+3. Consider restarting the app and test

--- a/plugins/uno-platform-studio/skills/uno-testing-ui/references/VISUAL-TREE-GUIDE.md
+++ b/plugins/uno-platform-studio/skills/uno-testing-ui/references/VISUAL-TREE-GUIDE.md
@@ -1,0 +1,255 @@
+# Visual Tree Inspection Guide
+
+This guide explains how to effectively use the `uno_app_visualtree_snapshot` tool to inspect and interact with UI elements in Uno Platform applications.
+
+## Understanding the Visual Tree
+
+The visual tree represents the hierarchical structure of all UI elements currently rendered in the application. Each element in the tree includes:
+
+- **Type**: The element class (Button, TextBox, Grid, etc.)
+- **Name**: The `x:Name` if defined in XAML
+- **Handle**: A unique reference for interaction tools
+- **Properties**: Relevant properties like Content, Text, IsEnabled
+- **Automation Properties**: AutomationId, Name, HelpText
+- **Bounds**: Position and size (when requested)
+
+## Tool Parameters
+
+### justMyCode (default: true)
+
+When `true`, filters the tree to show only elements defined in your application code:
+- Removes internal framework elements
+- Hides template internals
+- Shows cleaner, more navigable output
+
+Set to `false` when you need to:
+- Debug template issues
+- Interact with framework-level elements
+- Understand complete element composition
+
+### includeBounds (default: false)
+
+When `true`, includes element position and size:
+- X, Y coordinates (absolute physical pixels)
+- Width and Height
+- Useful for coordinate-based interactions
+
+Set to `true` when:
+- Using `uno_app_pointer_click`
+- Debugging layout issues
+- Calculating click positions
+
+### includeHidden (default: false)
+
+When `true`, includes hidden/collapsed elements:
+- Elements with `Visibility.Collapsed`
+- Elements with `Opacity = 0`
+- Elements outside the visible viewport
+
+Set to `true` when:
+- Looking for elements that may appear later
+- Debugging visibility binding issues
+- Testing conditional UI logic
+
+## Reading the XML Output
+
+### Basic Element Structure
+
+```xml
+<StackPanel handle="sp_001" Orientation="Vertical">
+  <TextBlock handle="tb_001" Text="Welcome" />
+  <Button handle="btn_001" x:Name="LoginButton" Content="Log In" IsEnabled="true">
+    <Button.AutomationProperties>
+      <AutomationId>LoginBtn</AutomationId>
+      <Name>Log In Button</Name>
+    </Button.AutomationProperties>
+  </Button>
+</StackPanel>
+```
+
+### Key Attributes to Look For
+
+| Attribute | Purpose |
+|-----------|---------|
+| `handle` | Required for interaction tools |
+| `x:Name` | Developer-assigned name |
+| `AutomationId` | Test automation identifier |
+| `Content` | Button/ContentControl content |
+| `Text` | TextBlock/TextBox text |
+| `IsEnabled` | Whether element accepts interaction |
+| `IsChecked` | Checkbox/Toggle state |
+
+### With Bounds Included
+
+```xml
+<Button handle="btn_001" 
+        x:Name="SubmitButton" 
+        Content="Submit"
+        Bounds="100,200,150,40">
+  <!-- X=100, Y=200, Width=150, Height=40 -->
+</Button>
+```
+
+The center point for clicking would be:
+- X: 100 + (150/2) = 175
+- Y: 200 + (40/2) = 220
+
+## Common Element Types
+
+### Layout Containers
+
+- `Grid` - Row/column-based layout
+- `StackPanel` - Linear stacking (horizontal or vertical)
+- `Border` - Single-child with border/background
+- `ScrollViewer` - Scrollable content area
+
+### Input Elements
+
+- `Button` - Clickable button (use default action)
+- `TextBox` - Text input (focus, then type)
+- `PasswordBox` - Secure text input
+- `ComboBox` - Dropdown selection
+- `CheckBox` - Boolean toggle
+- `RadioButton` - Exclusive selection
+- `Slider` - Range value selection
+- `ToggleSwitch` - On/off toggle
+
+### Display Elements
+
+- `TextBlock` - Read-only text
+- `Image` - Image display
+- `ProgressRing` / `ProgressBar` - Loading indicators
+- `ListView` / `ItemsRepeater` - List of items
+
+### Navigation Elements
+
+- `NavigationView` - Side navigation
+- `TabView` - Tab-based navigation
+- `Frame` - Page container
+
+## Finding Elements Strategies
+
+### By Name
+
+Look for `x:Name` attribute:
+```xml
+<Button x:Name="SaveButton" handle="btn_save" ... />
+```
+
+### By AutomationId
+
+Best practice for test automation:
+```xml
+<Button handle="btn_001">
+  <Button.AutomationProperties>
+    <AutomationId>SaveBtn</AutomationId>
+  </Button.AutomationProperties>
+</Button>
+```
+
+### By Content/Text
+
+For buttons and text elements:
+```xml
+<Button handle="btn_001" Content="Submit" />
+<TextBlock handle="tb_001" Text="Welcome, User" />
+```
+
+### By Type and Position
+
+When elements lack unique identifiers:
+1. Find parent container
+2. Look for elements by type in order
+3. Use the nth occurrence
+
+### By Hierarchy
+
+Navigate the tree structure:
+```xml
+<Page>
+  <Grid x:Name="RootGrid">
+    <StackPanel x:Name="LoginPanel">
+      <Button x:Name="LoginButton" handle="target_handle" />
+    </StackPanel>
+  </Grid>
+</Page>
+```
+
+## Handling Dynamic Content
+
+### Lists and Collections
+
+ListView items have handles but may be recycled:
+```xml
+<ListView handle="list_001">
+  <ListViewItem handle="item_001" Content="First Item" />
+  <ListViewItem handle="item_002" Content="Second Item" />
+  <ListViewItem handle="item_003" Content="Third Item" />
+</ListView>
+```
+
+**Important:** Item handles may change when scrolling. Always get a fresh snapshot before interacting.
+
+### Conditional UI
+
+Elements may appear/disappear based on state:
+- Use `includeHidden: true` to see collapsed elements
+- Refresh tree after state changes
+- Wait for async operations to complete
+
+### Loading Content
+
+During loading, you may see:
+- Empty containers
+- Placeholder elements
+- Progress indicators
+
+Wait for loading to complete before proceeding.
+
+## Debugging Tips
+
+### Element Not Found
+
+1. Set `justMyCode: false` to see all elements
+2. Set `includeHidden: true` to see collapsed elements
+3. Check if element is inside a different page/view
+4. Verify XAML defines the expected element
+
+### Wrong Element Focused
+
+1. Get visual tree to verify focus state
+2. Use Tab navigation to move focus
+3. Try clicking the element first
+
+### Stale Handles
+
+After significant UI changes:
+1. Always refresh the visual tree
+2. Use new handles from fresh snapshot
+3. Don't cache handles between operations
+
+## Performance Considerations
+
+### Large Trees
+
+For complex UIs, the tree can be large:
+- Use `justMyCode: true` to reduce size
+- Navigate to specific page/view first
+- Look for parent containers to narrow scope
+
+### Frequent Updates
+
+Don't call visual tree snapshot excessively:
+- Get snapshot before a series of related operations
+- Refresh only when state changes significantly
+- Cache element locations for multiple clicks in same area
+
+## Best Practices Summary
+
+1. **Always set justMyCode: true** unless debugging framework issues
+2. **Use AutomationId** for reliable element identification
+3. **Refresh tree after UI changes** before interacting
+4. **Get bounds only when needed** for coordinate clicks
+5. **Prefer handles over coordinates** for reliability
+6. **Check IsEnabled** before attempting interaction
+7. **Handle dynamic content** with fresh snapshots

--- a/plugins/uno-platform-studio/skills/uno-themes-material/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-themes-material/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: uno-themes-material
+description: "Comprehensive reference for the Uno Material theme — Material Design 3 styling for Uno Platform apps. Covers installation, the MD3 color palette and brush system, semantic typography, control styles (buttons, FAB, TextBox), control extensions (icons, elevation), lightweight styling, color/font customization, and version migration."
+when_to_use: "Use whenever working with Uno Material theming: setting up MaterialTheme or MaterialToolkitTheme, applying button / FAB / TextBox / typography styles, picking color palette keys, customizing colors or fonts via Theme Builder, applying lightweight styling overrides, adding control extensions (icons, elevation), or migrating between Material versions."
+metadata:
+  author: uno-platform
+  version: "1.0"
+  framework: uno-platform
+  category: themes
+---
+
+# Uno Material — Agent Skill
+
+Consolidated reference for the Uno Material theme. For any deep dive (full key tables, code samples, version-specific gotchas), fetch the authoritative docs via the steps below; the inline tables here cover the most-asked-for facts for fast lookup.
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Pick the relevant topic and search the docs
+
+| Topic | Search query |
+|---|---|
+| Installation / `MaterialTheme` / `UnoFeatures` | `uno_platform_docs_search("Uno Material installation MaterialTheme UnoFeatures")` |
+| Control styles (Button / TextBox / FAB / etc.) | `uno_platform_docs_search("Uno Material controls styles")` |
+| Color palette + brushes (MD3) | `uno_platform_docs_search("Uno Material colors brushes MD3 palette")` |
+| Typography / type scale | `uno_platform_docs_search("Uno Material typography type scale")` |
+| Lightweight styling (per-control overrides) | `uno_platform_docs_search("Uno Material lightweight styling resource keys")` |
+| Color customization / Theme Builder | `uno_platform_docs_search("Uno Material color customization Theme Builder DSP")` |
+| Font customization | `uno_platform_docs_search("Uno Material font customization font family override")` |
+| Control extensions (icons, elevation) | `uno_platform_docs_search("Uno Material control extensions icons elevation")` |
+| C# Markup with Material | `uno_platform_docs_search("Uno.Themes.WinUI.Markup C# Markup Material")` |
+| Version migration | `uno_platform_docs_search("Uno Material migration v1 v2 v3")` |
+
+### Step 2: Fetch the canonical pages
+
+- **Material Getting Started**: `external/uno.themes/doc/material-getting-started.md`
+- **Material Toolkit Getting Started**: `external/uno.toolkit.ui/doc/material-getting-started.md` (use `MaterialToolkitTheme` for Toolkit+Material)
+- **Material Controls Styles**: `external/uno.themes/doc/material-controls-styles.md`
+- **Lightweight Styling**: `external/uno.themes/doc/lightweight-styling.md`
+- **Material Migration**: `external/uno.themes/doc/material-migration.md`
+
+```
+uno_platform_docs_fetch(sourcePath="…")  # the sourcePath field from a search result above; never a URL/.html
+```
+
+## Critical Rules
+
+- **Brushes use `{ThemeResource}`, NOT `{StaticResource}`** — so the bound color follows the active theme (Light / Dark) at runtime. `<TextBlock Foreground="{ThemeResource PrimaryBrush}" />`.
+- **Styles use `{StaticResource}`** — control styles don't change with the theme; their internal bindings already use ThemeResource for brushes.
+- **Use `MaterialToolkitTheme` or `MaterialTheme`, not both** — when using both Toolkit + Material, `MaterialToolkitTheme` replaces `MaterialTheme + ToolkitResources`. Mixing them double-loads resources.
+
+## Installation (quick reference)
+
+In `.csproj`:
+```xml
+<UnoFeatures>Material</UnoFeatures>             <!-- or Material;Toolkit -->
+```
+
+In `App.xaml`:
+```xml
+<ResourceDictionary.MergedDictionaries>
+    <MaterialTheme xmlns="using:Uno.Material" />
+</ResourceDictionary.MergedDictionaries>
+```
+
+Use `<MaterialToolkitTheme xmlns="using:Uno.Toolkit.Material" />` if also using Uno Toolkit.
+
+## Control Style Keys (quick reference)
+
+### Button
+
+| Style key | Use for |
+|---|---|
+| `FilledButtonStyle` | **Default**. Primary actions ("Save", "Submit") |
+| `ElevatedButtonStyle` | Primary action with elevation/shadow |
+| `FilledTonalButtonStyle` | Secondary action; softer than Filled |
+| `OutlinedButtonStyle` | Secondary action with border |
+| `TextButtonStyle` | Tertiary / low-emphasis action |
+| `IconButtonStyle` | Icon-only action (pair with `Icons.Icon` attached property) |
+
+### FAB (FloatingActionButton; applied to `Button`)
+
+| Style key family | Sizes |
+|---|---|
+| `FabStyle` / `SmallFabStyle` / `LargeFabStyle` | Primary FAB |
+| `SecondaryFabStyle` / `SecondarySmallFabStyle` / `SecondaryLargeFabStyle` | Secondary color |
+| `TertiaryFabStyle` / `TertiarySmallFabStyle` / `TertiaryLargeFabStyle` | Tertiary color |
+| `SurfaceFabStyle` / `SurfaceSmallFabStyle` / `SurfaceLargeFabStyle` | Surface color |
+
+### TextBox / PasswordBox
+
+| Style key | Notes |
+|---|---|
+| `FilledTextBoxStyle` | **Material default** for TextBox |
+| `OutlinedTextBoxStyle` | Outlined variant |
+| `FilledPasswordBoxStyle` | **Material default** for PasswordBox |
+| `OutlinedPasswordBoxStyle` | Outlined variant |
+
+## Color Palette Keys (Layer 1)
+
+Material follows the MD3 role system. 32 color keys with Light/Dark variants. Most-used role families:
+
+- **Primary**: `PrimaryColor`, `OnPrimaryColor`, `PrimaryContainerColor`, `OnPrimaryContainerColor`, `PrimaryInverseColor`
+- **Secondary**: `SecondaryColor`, `OnSecondaryColor`, `SecondaryContainerColor`, `OnSecondaryContainerColor`
+- **Tertiary**: `TertiaryColor`, `OnTertiaryColor`, `TertiaryContainerColor`, `OnTertiaryContainerColor`
+- **Error**: `ErrorColor`, `OnErrorColor`, `ErrorContainerColor`, `OnErrorContainerColor`
+- **Surface**: `SurfaceColor`, `OnSurfaceColor`, `SurfaceVariantColor`, `OnSurfaceVariantColor`, `SurfaceInverseColor`, `OnSurfaceInverseColor`, `SurfaceTintColor`
+- **Background / Outline / Shadow**: `BackgroundColor`, `OnBackgroundColor`, `OutlineColor`, `OutlineVariantColor`, `ShadowColor`
+
+**Pairing rule**: every background role has a designated foreground role. `PrimaryBrush` ↔ `OnPrimaryBrush`. `ErrorContainerBrush` ↔ `OnErrorContainerBrush`. Don't mix unpaired colors. (See `uno-themes-semantic-colors-brushes` for the shared semantic surface common to Material + Simple.)
+
+## Brush System (Layer 2)
+
+Each color key generates ~9 brush variants with opacity tokens. Pattern: `{ColorRole}{StateVariant}Brush`.
+
+| Suffix | Opacity | Purpose |
+|---|---|---|
+| *(none)* | 1.0 | Rest state |
+| `Hover` | 0.08 | Pointer hover layer |
+| `Focused` | 0.12 | Keyboard focus layer |
+| `Pressed` | 0.12 | Active press layer |
+| `Dragged` | 0.16 | Drag operation layer |
+| `Selected` | 0.08 | Selected item layer |
+| `Medium` | 0.64 | Medium-emphasis text/icons |
+| `Low` | 0.32 | Low-emphasis text, placeholders |
+| `Disabled` | 0.12 | Disabled state |
+
+Total: ~288 brushes generated from the palette + opacity tokens.
+
+## Typography (Layer)
+
+M3 type scale, used as `TextBlock` styles. **Never theme-prefix typography keys** — write `DisplayLarge`, not `MaterialDisplayLarge`.
+
+| Family | Keys |
+|---|---|
+| Display | `DisplayLarge`, `DisplayMedium`, `DisplaySmall` |
+| Headline | `HeadlineLarge`, `HeadlineMedium`, `HeadlineSmall` |
+| Title | `TitleLarge`, `TitleMedium`, `TitleSmall` |
+| Body | `BodyLarge`, `BodyMedium`, `BodySmall` |
+| Label | `LabelLarge`, `LabelMedium`, `LabelSmall`, `LabelExtraSmall` |
+| Caption | `CaptionLarge`, `CaptionMedium`, `CaptionSmall` |
+
+Each style exposes `{StyleKey}FontFamily`, `FontSize`, `FontWeight` resource keys for lightweight styling overrides.
+
+## Control Extensions
+
+Material ships attached properties for icon, elevation, and toggle-content patterns (namespace `using:Uno.Material.Controls`):
+
+- **`Icons.Icon`** — adds an icon to a `Button` (esp. `IconButtonStyle`).
+- **Elevation extensions** — apply MD3 elevation shadows; layered with `ShadowContainer` for richer effects.
+- **Alternate content** — display different content based on `ToggleButton.IsChecked`.
+
+## Customization
+
+Three escalating scopes:
+
+1. **Palette override (full cascade)** — override `*Color` keys via `ColorOverrideSource` / `ColorOverrideDictionary` on `MaterialTheme`. All ~288 brushes and controls update automatically. Generate the palette XAML via **Material Theme Builder** (DSP format).
+2. **Specific brush override (targeted)** — drop a `<SolidColorBrush x:Key="FilledButtonBackground" Color="..." />` into App.xaml or scoped resources.
+3. **Per-instance override (scoped)** — wrap the override in the control's `Resources` block.
+
+Font override: set `FontOverrideSource` / `FontOverrideDictionary` on `MaterialTheme`, or override individual `*FontFamily` keys.
+
+## C# Markup
+
+Use `Uno.Themes.WinUI.Markup` for fluent C# styling — `.MaterialFilledButtonStyle()`, `.MaterialOutlinedTextBoxStyle()`, etc. Resource keys exposed as constants under `MaterialThemeResources`.
+
+```csharp
+new Button().Content("Save").MaterialFilledButtonStyle()
+```
+
+## Migration
+
+Between major versions, resource keys, converters, and style names can change. Fetch the migration page on upgrade:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.themes/doc/material-migration.md")
+```
+
+Key checks: renamed resource keys, removed converters, NuGet package renames, `UnoFeatures` flag changes.
+
+## Related Skills
+
+- [[uno-themes-semantic-colors-brushes]] — Shared semantic design language (style keys + typography + colors that work across Material AND Simple themes). Read this first if styling needs to be portable between themes.
+- [[uno-themes-simple]] — Simple theme specifics. Use when targeting Simple (designer/wireframe look) or its theme-specific styles (danger buttons, size variants, utility brushes, PersonPicture, etc.).
+- [[uno-toolkit-material-theme]] — `MaterialToolkitTheme` setup for Toolkit + Material.

--- a/plugins/uno-platform-studio/skills/uno-themes-semantic-colors-brushes/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-themes-semantic-colors-brushes/SKILL.md
@@ -1,0 +1,379 @@
+---
+name: uno-themes-semantic-colors-brushes
+description: "Comprehensive reference for the Uno Themes Semantic Design Language. Covers semantic control styles, typography, 33 color palette keys, ~288 generated brushes, opacity/state system, color pairing rules, and theme customization."
+when_to_use: "Use when styling apps with Uno Themes, choosing correct semantic style keys, using typography resources, selecting color roles, customizing the color palette, or understanding the relationship between colors, brushes, styles, and interactive states."
+metadata:
+  author: custom
+  version: "2.7"
+  framework: uno-platform
+  category: themes
+---
+
+# Uno Themes Semantic Design Language
+
+This skill is the definitive reference for the **Semantic Design Language** in Uno Themes. The semantic system is **design-theme agnostic** -- the same style keys, typography keys, color keys, and brush keys are shared across every design-theme implementation. Each implementation supplies its own concrete values and may not implement every key, but the semantic names are shared. Consult the design-theme-specific skills for concrete styles, palettes, and theme-only extensions.
+
+---
+
+## Part 1: Semantic Control Styles
+
+### How It Works
+
+Each design-theme's `_Resources.xaml` defines `<StaticResource>` aliases that map the shared semantic key to the theme's concrete style (e.g. `FilledButtonStyle` -> `{ThemePrefix}FilledButtonStyle`).
+
+Use semantic keys in XAML for portable, theme-agnostic styling:
+
+```xml
+<Button Style="{StaticResource FilledButtonStyle}" Content="Save" />
+```
+
+### Complete Style Key Reference
+
+| Semantic Key | Control | Default | Notes |
+|---|---|---|---|
+| `FilledButtonStyle` | `Button` | Yes | |
+| `ElevatedButtonStyle` | `Button` | | Not implemented by every design-theme |
+| `FilledTonalButtonStyle` | `Button` | | |
+| `OutlinedButtonStyle` | `Button` | | Not implemented by every design-theme |
+| `TextButtonStyle` | `Button` | | |
+| `IconButtonStyle` | `Button` | | |
+| `TextToggleButtonStyle` | `ToggleButton` | | |
+| `IconToggleButtonStyle` | `ToggleButton` | Yes | Default implicit for ToggleButton |
+| `FilledTextBoxStyle` | `TextBox` | | |
+| `OutlinedTextBoxStyle` | `TextBox` | | Implicit default in some design-themes |
+| `FilledPasswordBoxStyle` | `PasswordBox` | | |
+| `OutlinedPasswordBoxStyle` | `PasswordBox` | | Implicit default in some design-themes |
+| `ComboBoxStyle` | `ComboBox` | Yes | |
+| `ComboBoxItemStyle` | `ComboBoxItem` | | |
+| `CheckBoxStyle` | `CheckBox` | Yes | |
+| `RadioButtonStyle` | `RadioButton` | Yes | |
+| `ToggleSwitchStyle` | `ToggleSwitch` | Yes | |
+| `SliderStyle` | `Slider` | Yes | |
+| `HyperlinkButtonStyle` | `HyperlinkButton` | Yes | |
+| `SecondaryHyperlinkButtonStyle` | `HyperlinkButton` | | |
+| `ListViewStyle` | `ListView` | Yes | |
+| `ListViewItemStyle` | `ListViewItem` | Yes | |
+| `ContentDialogStyle` | `ContentDialog` | Yes | |
+| `CommandBarStyle` | `CommandBar` | Yes | Not implemented by every design-theme |
+| `AppBarButtonStyle` | `AppBarButton` | Yes | |
+| `NavigationViewStyle` | `NavigationView` | Yes | |
+| `NavigationViewItemStyle` | `NavigationViewItem` | Yes | |
+| `CalendarViewStyle` | `CalendarView` | Yes | |
+| `CalendarDatePickerStyle` | `CalendarDatePicker` | Yes | |
+| `DatePickerStyle` | `DatePicker` | Yes | |
+| `DatePickerFlyoutPresenterStyle` | `DatePickerFlyoutPresenter` | Yes | Not implemented by every design-theme |
+| `MediaTransportControlsStyle` | `MediaTransportControls` | Yes | Not implemented by every design-theme |
+| `ProgressBarStyle` | `ProgressBar` | Yes | |
+| `ProgressRingStyle` | `ProgressRing` | Yes | |
+| `PipsPagerStyle` | `PipsPager` | Yes | |
+| `RatingControlStyle` | `RatingControl` | Yes | |
+| `FlyoutPresenterStyle` | `FlyoutPresenter` | Yes | |
+| `MenuFlyoutPresenterStyle` | `MenuFlyoutPresenter` | Yes | |
+| `MenuFlyoutItemStyle` | `MenuFlyoutItem` | Yes | |
+| `MenuFlyoutSeparatorStyle` | `MenuFlyoutSeparator` | Yes | |
+| `MenuFlyoutSubItemStyle` | `MenuFlyoutSubItem` | Yes | |
+| `ToggleMenuFlyoutItemStyle` | `ToggleMenuFlyoutItem` | Yes | |
+| `RadioMenuFlyoutItemStyle` | `RadioMenuFlyoutItem` | Yes | |
+
+#### FAB Styles
+
+| Semantic Key | Control | Notes |
+|---|---|---|
+| `FabStyle` | `Button` | Primary FAB |
+| `SmallFabStyle` | `Button` | |
+| `LargeFabStyle` | `Button` | |
+| `SecondaryFabStyle` | `Button` | |
+| `SecondarySmallFabStyle` | `Button` | |
+| `SecondaryLargeFabStyle` | `Button` | |
+| `TertiaryFabStyle` | `Button` | |
+| `TertiarySmallFabStyle` | `Button` | |
+| `TertiaryLargeFabStyle` | `Button` | |
+| `SurfaceFabStyle` | `Button` | |
+| `SurfaceSmallFabStyle` | `Button` | |
+| `SurfaceLargeFabStyle` | `Button` | |
+
+> **Note:** Individual design-themes may also expose additional theme-prefixed styles (e.g. danger variants, size variants, controls without a cross-theme equivalent) that are **not** part of the shared semantic surface. See the design-theme-specific skills for those.
+
+---
+
+## Part 2: Semantic Typography
+
+Each design-theme provides semantic typography keys based on the M3 type scale. Concrete font families, sizes, and weights are supplied by the active design-theme's `Typography.xaml`; the semantic key names are shared.
+
+### Typography Style Keys
+
+Use these as TextBlock styles:
+
+```xml
+<TextBlock Style="{StaticResource DisplayLarge}" Text="Hero" />
+<TextBlock Style="{StaticResource BodyMedium}" Text="Body text" />
+```
+
+### Font Resource Keys
+
+Each typography style exposes individual font properties for lightweight styling:
+
+| Style Key | Font Resource Keys |
+|---|---|
+| `DisplayLarge` | `DisplayLargeFontFamily`, `DisplayLargeFontSize`, `DisplayLargeFontWeight`, `DisplayLargeCharacterSpacing` |
+| `DisplayMedium` | `DisplayMediumFontFamily`, `DisplayMediumFontSize`, `DisplayMediumFontWeight` |
+| `DisplaySmall` | `DisplaySmallFontFamily`, `DisplaySmallFontSize`, `DisplaySmallFontWeight` |
+| `HeadlineLarge` | `HeadlineLargeFontFamily`, `HeadlineLargeFontSize`, `HeadlineLargeFontWeight` |
+| `HeadlineMedium` | `HeadlineMediumFontFamily`, `HeadlineMediumFontSize`, `HeadlineMediumFontWeight` |
+| `HeadlineSmall` | `HeadlineSmallFontFamily`, `HeadlineSmallFontSize`, `HeadlineSmallFontWeight` |
+| `TitleLarge` | `TitleLargeFontFamily`, `TitleLargeFontSize`, `TitleLargeFontWeight` |
+| `TitleMedium` | `TitleMediumFontFamily`, `TitleMediumFontSize`, `TitleMediumFontWeight` |
+| `TitleSmall` | `TitleSmallFontFamily`, `TitleSmallFontSize`, `TitleSmallFontWeight` |
+| `BodyLarge` | `BodyLargeFontFamily`, `BodyLargeFontSize`, `BodyLargeFontWeight` |
+| `BodyMedium` | `BodyMediumFontFamily`, `BodyMediumFontSize`, `BodyMediumFontWeight` |
+| `BodySmall` | `BodySmallFontFamily`, `BodySmallFontSize`, `BodySmallFontWeight` |
+| `LabelLarge` | `LabelLargeFontFamily`, `LabelLargeFontSize`, `LabelLargeFontWeight` |
+| `LabelMedium` | `LabelMediumFontFamily`, `LabelMediumFontSize`, `LabelMediumFontWeight` |
+| `LabelSmall` | `LabelSmallFontFamily`, `LabelSmallFontSize`, `LabelSmallFontWeight` |
+| `LabelExtraSmall` | `LabelExtraSmallFontFamily`, `LabelExtraSmallFontSize`, `LabelExtraSmallFontWeight` |
+| `CaptionLarge` | `CaptionLargeFontFamily`, `CaptionLargeFontSize`, `CaptionLargeFontWeight` |
+| `CaptionMedium` | `CaptionMediumFontFamily`, `CaptionMediumFontSize`, `CaptionMediumFontWeight` |
+| `CaptionSmall` | `CaptionSmallFontFamily`, `CaptionSmallFontSize`, `CaptionSmallFontWeight` |
+
+### Typography Decision Guide
+
+| Purpose | Style Key |
+|---------|-----------|
+| Hero / splash text | `DisplayLarge` |
+| Page title | `DisplayMedium` or `HeadlineLarge` |
+| Section heading | `HeadlineMedium` or `HeadlineSmall` |
+| Card / dialog title | `TitleLarge` or `TitleMedium` |
+| Button / tab label | `LabelLarge` |
+| Primary body text | `BodyLarge` |
+| Secondary body text | `BodyMedium` |
+| Caption / helper text | `CaptionMedium` or `BodySmall` |
+| Badge / small label | `LabelSmall` or `LabelExtraSmall` |
+
+---
+
+## Part 3: Semantic Colors & Brushes
+
+### Architecture: Three Layers
+
+```
+Layer 1: Color Palette (SharedColorPalette.xaml)
+    33 Color resources with Light/Dark theme variants
+           |
+           v
+Layer 2: Semantic Brushes (SharedColors.xaml)
+    ~288 SolidColorBrush resources generated from palette + opacity tokens
+           |
+           v
+Layer 3: Control Lightweight Styling Keys
+    Per-control resource keys that reference semantic brushes
+    (e.g., FilledButtonBackground -> PrimaryBrush)
+```
+
+- **Override Layer 1** to rebrand the entire app (all brushes cascade automatically).
+- **Override Layer 2** to change a specific brush without affecting the palette.
+- **Override Layer 3** to change a single control's appearance without affecting the brush system.
+
+### The Color Palette (Layer 1)
+
+Defined in `SharedColorPalette.xaml`, these 33 `Color` resources are the foundation.
+
+#### Primary -- Brand Identity & Key Actions
+
+| Color Key | Role | When to Use |
+|-----------|------|-------------|
+| `PrimaryColor` | Hero brand color | Filled button backgrounds, active toggle states, FAB backgrounds |
+| `OnPrimaryColor` | Content on Primary | Text and icons on Primary surfaces |
+| `PrimaryContainerColor` | Softer primary fill | Tonal button backgrounds, selected navigation items, chips |
+| `OnPrimaryContainerColor` | Content on Primary Container | Text and icons on PrimaryContainer surfaces |
+| `PrimaryInverseColor` | Inverted primary accent | Links on inverse surfaces (e.g., dark snackbar) |
+
+#### Legacy Primary Variants
+
+| Color Key | Role |
+|-----------|------|
+| `PrimaryVariantDarkColor` | Darker primary shade (M2 compat) |
+| `PrimaryVariantLightColor` | Lighter primary shade (M2 compat) |
+
+#### Secondary -- Supporting Accents
+
+| Color Key | Role | When to Use |
+|-----------|------|-------------|
+| `SecondaryColor` | Supporting accent | Filter chips, secondary action buttons |
+| `OnSecondaryColor` | Content on Secondary | Text and icons on Secondary surfaces |
+| `SecondaryContainerColor` | Softer secondary fill | NavigationView selected item, info banners |
+| `OnSecondaryContainerColor` | Content on Secondary Container | Text and icons on SecondaryContainer |
+
+#### Legacy Secondary Variants
+
+| Color Key | Role |
+|-----------|------|
+| `SecondaryVariantDarkColor` | Darker secondary shade (M2 compat) |
+| `SecondaryVariantLightColor` | Lighter secondary shade (M2 compat) |
+
+#### Tertiary -- Contrast & Balance
+
+| Color Key | Role | When to Use |
+|-----------|------|-------------|
+| `TertiaryColor` | Third accent | Tertiary FABs, accents distinct from Primary and Secondary |
+| `OnTertiaryColor` | Content on Tertiary | Text and icons on Tertiary surfaces |
+| `TertiaryContainerColor` | Softer tertiary fill | Complementary cards, input fields |
+| `OnTertiaryContainerColor` | Content on Tertiary Container | Text and icons on TertiaryContainer |
+
+#### Error -- Validation & Destructive Actions
+
+| Color Key | Role | When to Use |
+|-----------|------|-------------|
+| `ErrorColor` | Danger/error accent | Error text, destructive button backgrounds |
+| `OnErrorColor` | Content on Error | Text and icons on Error surfaces |
+| `ErrorContainerColor` | Softer error fill | Error banners, validation backgrounds |
+| `OnErrorContainerColor` | Content on Error Container | Text and icons on ErrorContainer |
+
+#### Surface -- Component Backgrounds
+
+| Color Key | Role | When to Use |
+|-----------|------|-------------|
+| `SurfaceColor` | Default component background | Cards, dialogs, sheets, menus |
+| `OnSurfaceColor` | Primary text/icons | Highest-emphasis content: titles, body text |
+| `SurfaceVariantColor` | Differentiated surface | ToggleSwitch tracks, Slider tracks, subtle section backgrounds |
+| `OnSurfaceVariantColor` | Secondary text/icons | Helper text, captions, lower-emphasis icons |
+| `SurfaceInverseColor` | Inverted surface | Snackbars, tooltips |
+| `OnSurfaceInverseColor` | Content on inverse surface | Text on snackbars and tooltips |
+| `SurfaceTintColor` | Elevation tint | Tint overlay for elevated surfaces |
+
+#### Background, Outline, Shadow
+
+| Color Key | Role |
+|-----------|------|
+| `BackgroundColor` | Root page background |
+| `OnBackgroundColor` | Content on background |
+| `OutlineColor` | Interactive boundaries (button borders, input outlines) |
+| `OutlineVariantColor` | Decorative boundaries (card edges, dividers) |
+| `ShadowColor` | Drop shadow color |
+
+### The Brush System (Layer 2)
+
+Every Color key generates **9 SolidColorBrush variants** at different opacity levels.
+
+#### Brush Naming Pattern: `{ColorRole}{StateVariant}Brush`
+
+| Suffix | Opacity | Purpose |
+|--------|---------|---------|
+| *(none)* | 1.0 | Default/rest state |
+| `Hover` | 0.08 | Pointer hover state layer |
+| `Focused` | 0.12 | Keyboard focus state layer |
+| `Pressed` | 0.12 | Active press state layer |
+| `Dragged` | 0.16 | Drag operation state layer |
+| `Selected` | 0.08 | Selected item state layer |
+| `Medium` | 0.64 | Medium-emphasis text/icons |
+| `Low` | 0.32 | Low-emphasis text, placeholders |
+| `Disabled` | 0.12 | Disabled state backgrounds |
+
+**Total: ~288 semantic brushes** across Primary (63), Secondary (54), Tertiary (36), Error (36), Surface (63), Background (18), Outline (18).
+
+### Color Pairing Rules (CRITICAL)
+
+**NEVER mix unpaired colors.** Every background role has a designated "On" foreground role.
+
+| If Background Is... | Then Foreground MUST Be... |
+|----------------------|---------------------------|
+| `PrimaryBrush` | `OnPrimaryBrush` |
+| `PrimaryContainerBrush` | `OnPrimaryContainerBrush` |
+| `SecondaryBrush` | `OnSecondaryBrush` |
+| `SecondaryContainerBrush` | `OnSecondaryContainerBrush` |
+| `TertiaryBrush` | `OnTertiaryBrush` |
+| `TertiaryContainerBrush` | `OnTertiaryContainerBrush` |
+| `ErrorBrush` | `OnErrorBrush` |
+| `ErrorContainerBrush` | `OnErrorContainerBrush` |
+| `SurfaceBrush` | `OnSurfaceBrush` or `OnSurfaceVariantBrush` |
+| `SurfaceVariantBrush` | `OnSurfaceVariantBrush` |
+| `BackgroundBrush` | `OnBackgroundBrush` |
+| `SurfaceInverseBrush` | `OnSurfaceInverseBrush` |
+
+### Text Emphasis on Surfaces
+
+| Emphasis | Brush | Use For |
+|----------|-------|---------|
+| High | `OnSurfaceBrush` | Titles, headings, primary labels |
+| Medium | `OnSurfaceVariantBrush` | Body text, secondary labels, captions |
+| Low / Disabled | `OnSurfaceLowBrush` | Disabled text, placeholder text |
+
+---
+
+## Part 4: Customization
+
+### Method 1: Override Color Palette (Full Cascade)
+
+Override `*Color` keys in a ResourceDictionary referenced by your theme. All ~288 brushes and controls update automatically.
+
+**Always provide both** `Light` and `Default` (Dark) theme values.
+
+### Method 2: Override Specific Brushes (Targeted)
+
+```xml
+<SolidColorBrush x:Key="FilledButtonBackground" Color="#006D3B" />
+```
+
+### Method 3: Override Per-Control Instance (Scoped)
+
+```xml
+<Button Style="{StaticResource FilledButtonStyle}">
+    <Button.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light">
+                    <SolidColorBrush x:Key="FilledButtonBackground" Color="#006D3B" />
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+        </ResourceDictionary>
+    </Button.Resources>
+</Button>
+```
+
+### Customization Precedence (Highest to Lowest)
+
+1. **Control.Resources** -- per-instance
+2. **Page.Resources** -- page-scoped
+3. **App-level overrides** -- app-wide
+4. **Theme defaults** -- active design-theme
+5. **SharedColorPalette / SharedColors / SharedTypography** -- foundation
+
+---
+
+## Decision Guides
+
+### Which Color Role?
+
+| Scenario | Background | Foreground |
+|----------|------------|------------|
+| Primary CTA ("Submit") | `PrimaryBrush` | `OnPrimaryBrush` |
+| Tonal action | `SecondaryContainerBrush` | `OnSecondaryContainerBrush` |
+| Outlined button border | `OutlineBrush` | `PrimaryBrush` |
+| Text-only action | Transparent | `PrimaryBrush` |
+| Destructive ("Delete") | `ErrorBrush` | `OnErrorBrush` |
+| Card / Dialog | `SurfaceBrush` | `OnSurfaceBrush` |
+| Error banner | `ErrorContainerBrush` | `OnErrorContainerBrush` |
+| Snackbar / Tooltip | `SurfaceInverseBrush` | `OnSurfaceInverseBrush` |
+
+### Which Button Style?
+
+| Scenario | Style Key |
+|----------|-----------|
+| Primary action | `FilledButtonStyle` |
+| Secondary action | `FilledTonalButtonStyle` or `OutlinedButtonStyle` |
+| Tertiary / low emphasis | `TextButtonStyle` |
+| Icon-only action | `IconButtonStyle` |
+
+### XAML Best Practices
+
+- Always use `ThemeResource` (not `StaticResource`) for brushes so they respond to theme changes.
+- Always use `StaticResource` for styles (styles don't change with theme).
+- Use semantic keys, not theme-prefixed keys, for portable XAML.
+
+```xml
+<!-- Correct -->
+<Button Style="{StaticResource FilledButtonStyle}"
+        Content="Save" />
+
+<!-- Avoid theme-prefixed keys in portable code -->
+<!-- <Button Style="{StaticResource {ThemePrefix}FilledButtonStyle}" /> -->
+```

--- a/plugins/uno-platform-studio/skills/uno-themes-simple/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-themes-simple/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: uno-themes-simple
+description: "Comprehensive reference for the Uno Simple theme — designer/wireframe-style theming for Uno Platform apps. Covers SimpleTheme configuration (color/font overrides, default size), Simple-specific style keys (danger buttons, size variants, error inputs, PersonPicture variants), controls without Material equivalent (Expander, AutoSuggestBox, ToolTip, PersonPicture), Simple utility brushes (overlays, scrims, measurement/debug), and the Simple-specific pink primitive scale."
+when_to_use: "Use when targeting the Uno Simple theme — setting up `SimpleTheme`, choosing Simple-only style keys (danger buttons, Small/Medium size variants, error inputs, PersonPicture variants), styling controls that exist only in Simple (Expander, AutoSuggestBox, ToolTip), overriding the Inter font or the grayscale palette, or working with Simple's utility brush family (overlays, scrims, measurement/debug)."
+metadata:
+  author: uno-platform
+  version: "1.0"
+  framework: uno-platform
+  category: themes
+---
+
+# Uno Simple Theme — Agent Skill
+
+The Simple theme is Uno's designer/wireframe-style theme. It shares the semantic surface (style keys, typography keys, color keys, brush keys) with Material via the **Semantic Design Language** — see `uno-themes-semantic-colors-brushes` for the shared layer. This skill covers the **Simple-only** style keys, brushes, and `SimpleTheme` configuration that are not portable to other themes.
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Search the docs for the topic
+
+| Topic | Search query |
+|---|---|
+| Installation / `SimpleTheme` setup | `uno_platform_docs_search("Uno Simple theme installation SimpleTheme UnoFeatures")` |
+| Simple style keys (buttons, inputs, etc.) | `uno_platform_docs_search("Uno Simple controls styles danger size variants")` |
+| `DefaultSize` (Small / Medium) | `uno_platform_docs_search("Uno Simple DefaultSize SimpleControlSize button height")` |
+| Color override / palette | `uno_platform_docs_search("Uno Simple ColorOverrideSource palette grayscale")` |
+| Font override | `uno_platform_docs_search("Uno Simple FontOverrideSource Inter font family")` |
+| Utility brushes (overlays, scrims) | `uno_platform_docs_search("Uno Simple utility brushes overlay scrim measurement")` |
+
+### Step 2: Fetch a page
+
+Uno's published docs have **no Simple-theme-specific pages** — the inline tables in this skill are the authoritative reference for Simple. For cross-theme topics, search and fetch the `sourcePath` from a result, e.g. lightweight styling:
+
+- **Lightweight Styling** (cross-theme): `external/uno.themes/doc/lightweight-styling.md`
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.themes/doc/lightweight-styling.md")
+```
+
+## Critical Rules
+
+- **Simple uses a flat grayscale palette** for all roles except Error (which uses red). Primary, Secondary, Tertiary, Surface, and Outline are achromatic grays. To introduce brand colors, override the palette via `ColorOverrideSource` / `ColorOverrideDictionary`.
+- **Simple defaults to Inter** for all typography (`SimpleFontFamily`); `CharacterSpacing=0` on all styles; font weights are `Bold` / `SemiBold` / `Normal` (no `Medium`).
+- **Typography style keys are NEVER theme-prefixed.** Write `DisplayLarge`, `BodyMedium`, `LabelSmall` — NOT `SimpleDisplayLarge`. The theme-prefix pattern only applies to the Simple-only control styles listed below.
+- **`DefaultSize` affects implicit styles only.** Setting `<SimpleTheme DefaultSize="Medium" />` switches the unsized button / icon-button / toggle-button defaults from 32px (Small) to 40px (Medium). Size-specific styles (`SimpleSmall*`, `SimpleMedium*`) always use their declared size regardless of `DefaultSize`.
+
+## SimpleTheme Configuration
+
+`SimpleTheme` (namespace `using:Uno.Simple`) accepts:
+
+| Property | Type | Default | Purpose |
+|---|---|---|---|
+| `ColorOverrideSource` | `string` (URI) | — | Path to a XAML ResourceDictionary overriding `*Color` keys |
+| `ColorOverrideDictionary` | `ResourceDictionary` | — | Inline ResourceDictionary overriding `*Color` keys |
+| `FontOverrideSource` | `string` (URI) | — | Path to a XAML ResourceDictionary overriding font resources |
+| `FontOverrideDictionary` | `ResourceDictionary` | — | Inline ResourceDictionary overriding font resources |
+| `DefaultSize` | `SimpleControlSize` | `Small` | Default size variant for buttons / icon buttons / toggle buttons |
+
+```xml
+<SimpleTheme xmlns="using:Uno.Simple"
+             ColorOverrideSource="ms-appx:///Styles/Application/ColorOverride.xaml"
+             FontOverrideSource="ms-appx:///Styles/Application/FontOverride.xaml"
+             DefaultSize="Medium" />
+```
+
+When overriding the palette, **always provide both `Light` and `Default` (Dark) theme values**.
+
+## Simple-Only Style Keys
+
+### Button Variants (no Material equivalent)
+
+| Style Key | Control | Use For |
+|---|---|---|
+| `SimpleDangerPrimaryButtonStyle` | `Button` | Destructive filled action ("Delete account") |
+| `SimpleDangerSubtleButtonStyle` | `Button` | Destructive text action |
+| `SimpleIconButtonNeutralStyle` | `Button` | Neutral (secondary) icon button |
+| `SimpleIconButtonSubtleStyle` | `Button` | Subtle (tertiary) icon button |
+| `SimpleIconButtonDangerPrimaryStyle` | `Button` | Destructive filled icon button |
+| `SimpleIconButtonDangerSubtleStyle` | `Button` | Destructive subtle icon button |
+
+### Size Variants (Small / Medium)
+
+Pattern: `Simple{Size}{Style}`. `Small` = 32px, `Medium` = 40px (button height).
+
+| Size | Button | Icon Button | ToggleButton |
+|---|---|---|---|
+| Small | `SimpleSmallFilledButtonStyle`, `SimpleSmallFilledTonalButtonStyle`, `SimpleSmallTextButtonStyle`, `SimpleSmallDangerPrimaryButtonStyle`, `SimpleSmallDangerSubtleButtonStyle` | `SimpleSmallIconButtonStyle`, `SimpleSmallIconButtonNeutralStyle`, `SimpleSmallIconButtonSubtleStyle`, `SimpleSmallIconButtonDangerPrimaryStyle`, `SimpleSmallIconButtonDangerSubtleStyle` | `SimpleSmallToggleButtonStyle` |
+| Medium | `SimpleMediumFilledButtonStyle`, `SimpleMediumFilledTonalButtonStyle`, `SimpleMediumTextButtonStyle`, `SimpleMediumDangerPrimaryButtonStyle`, `SimpleMediumDangerSubtleButtonStyle` | `SimpleMediumIconButtonStyle`, `SimpleMediumIconButtonNeutralStyle`, `SimpleMediumIconButtonSubtleStyle`, `SimpleMediumIconButtonDangerPrimaryStyle`, `SimpleMediumIconButtonDangerSubtleStyle` | `SimpleMediumToggleButtonStyle` |
+
+### Input Variants
+
+| Style Key | Control | Use For |
+|---|---|---|
+| `SimpleTextBoxErrorStyle` | `TextBox` | Error / validation state |
+| `SimpleTextBoxSmallStyle` | `TextBox` | Small size variant |
+| `SimpleComboBoxErrorStyle` | `ComboBox` | Error / validation state |
+
+### Controls Without Material Equivalent
+
+| Style Key | Control | Notes |
+|---|---|---|
+| `SimpleExpanderStyle` | `Expander` | No Material counterpart |
+| `SimpleAutoSuggestBoxStyle` | `AutoSuggestBox` | No Material counterpart |
+| `SimpleToolTipStyle` | `ToolTip` | No Material counterpart |
+| `SimplePersonPictureStyle` | `PersonPicture` | Circular, medium (default) |
+| `SimplePersonPictureSmallStyle` | `PersonPicture` | Circular, small |
+| `SimplePersonPictureLargeStyle` | `PersonPicture` | Circular, large |
+| `SimplePersonPictureSquareStyle` | `PersonPicture` | Square (rounded), medium |
+| `SimplePersonPictureSquareSmallStyle` | `PersonPicture` | Square (rounded), small |
+| `SimplePersonPictureSquareLargeStyle` | `PersonPicture` | Square (rounded), large |
+
+## Simple-Specific Utility Brushes
+
+Beyond the shared semantic brushes, Simple defines utility brushes for overlays, scrims, and measurement/debug overlays. Defined in Simple's `ColorPalette.xaml`; no shared equivalent.
+
+| Brush Key | Light | Dark | Purpose |
+|---|---|---|---|
+| `SimpleBackgroundUtilitiesBlanketBrush` | `#B2000000` | `#B2000000` | Heavy overlay / blanket |
+| `SimpleBackgroundUtilitiesMeasurementBrush` | Pink 200 | Pink 800 | Measurement overlay background |
+| `SimpleBackgroundUtilitiesOverlayBrush` | `#80000000` | `#80000000` | Semi-transparent overlay |
+| `SimpleBackgroundUtilitiesScrimBrush` | `#CCFFFFFF` | `#CC000000` | Scrim behind dialogs / sheets |
+| `SimpleTextUtilitiesOnMeasurementBrush` | Pink 800 | Pink 200 | Text on measurement surfaces |
+| `SimpleTextUtilitiesOnOverlayBrush` | `OnSurfaceInverseBrush` | `OnSurfaceBrush` | Text on overlay surfaces |
+| `SimpleIconUtilitiesBrush` | Pink 600 | Pink 400 | Measurement / debug icons |
+| `SimpleIconUtilitiesOnMeasurementBrush` | Pink 800 | Pink 200 | Icons on measurement surfaces |
+| `SimpleBorderUtilitiesMeasurementBrush` | Pink 400 | Pink 600 | Measurement / debug borders |
+| `SimpleBorderUtilitiesSwatchBrush` | `#3D000000` | `#3DFFFFFF` | Color swatch borders |
+
+These reference a Simple-specific **pink primitive scale**: `SimplePink200Color` through `SimplePink800Color`. Pink values **intentionally swap** between light and dark themes to maintain contrast.
+
+## Customization Methods
+
+Simple supports five escalating overrides (ordered by scope):
+
+1. **Override color palette (full cascade)** — `ColorOverrideSource` / `ColorOverrideDictionary` on `SimpleTheme`. All brushes cascade.
+2. **Switch default size variant** — `DefaultSize="Medium"` on `SimpleTheme`. Affects implicit button / icon-button / toggle-button styles only; size-named variants are unaffected.
+3. **Override specific brushes (targeted)** — `<SolidColorBrush x:Key="FilledButtonBackground" Color="..." />` in App.xaml.
+4. **Override per-control instance (scoped)** — wrap the brush override inside the control's `Resources` block.
+5. **Override font family** — `FontOverrideSource` / `FontOverrideDictionary` on `SimpleTheme`, or override `SimpleFontFamily` directly. Default is **Inter**.
+
+Customization precedence (highest → lowest): per-instance `Control.Resources` → `Page.Resources` → app-level overrides → `SimpleTheme` defaults → `SharedColorPalette` / `SharedColors` / `SharedTypography` foundation.
+
+## Related Skills
+
+- [[uno-themes-semantic-colors-brushes]] — **Read this first** for the shared semantic surface (style keys, typography, palette, brushes) common to Simple AND Material. Most styling should use those portable keys; reach for Simple-prefixed styles only when targeting Simple-specific concepts (danger variants, explicit sizes, Expander, etc.).
+- [[uno-themes-material]] — Material theme reference. Use when targeting Material instead of (or alongside) Simple.

--- a/plugins/uno-platform-studio/skills/uno-toolkit-ancestor-binding/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-ancestor-binding/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: uno-toolkit-ancestor-binding
+description: "Use AncestorBinding and ItemsControlBinding markup extensions for relative binding from within DataTemplates. Access parent DataContext."
+when_to_use: "Use when binding inside a `DataTemplate` needs to reach the outer `DataContext`, the page's ViewModel, or an ancestor `ItemsControl` — the Uno equivalent of WPF's `RelativeSource FindAncestor`. `ItemsControlBinding` exposes the parent ItemsControl's own `DataContext` from within its item template."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit AncestorBinding — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the AncestorBinding Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit AncestorBinding ItemsControlBinding relative binding DataTemplate ancestor")
+```
+
+Primary documentation page:
+- **AncestorBinding & ItemsControlBinding**: `external/uno.toolkit.ui/doc/helpers/ancestor-itemscontrol-binding.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/helpers/ancestor-itemscontrol-binding.md")
+```
+
+## Key Principles (Stable)
+
+- `{utu:AncestorBinding AncestorType=MyControl, Path=DataContext.MyProperty}` — binds to an ancestor's DataContext
+- `{utu:ItemsControlBinding Path=DataContext.MyCommand}` — shorthand for binding to the parent ItemsControl's DataContext
+- Similar to WPF's `{RelativeSource Mode=FindAncestor, AncestorType=...}`
+- Essential for commands in DataTemplates that need to call the page's ViewModel
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-command-extensions]] — Commands in templates

--- a/plugins/uno-platform-studio/skills/uno-toolkit-autolayout/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-autolayout/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: uno-toolkit-autolayout
+description: "Use AutoLayout control to arrange children with Figma-like spacing, alignment, and padding."
+when_to_use: "Use when building layouts that mirror Figma Auto-Layout, arranging children in rows or columns with uniform spacing, using space-between distribution, per-child alignment overrides (CounterAlignment), or converting Figma designs to XAML."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: toolkit
+---
+
+# Uno Toolkit AutoLayout — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the AutoLayout Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit AutoLayout panel Figma spacing alignment")
+```
+
+Primary documentation page:
+- **AutoLayout Control**: `external/uno.toolkit.ui/doc/controls/AutoLayoutControl.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/AutoLayoutControl.md")
+```
+
+### Step 2: For How-To Walkthroughs
+
+```
+uno_platform_docs_search("AutoLayout howto walkthrough example Figma")
+```
+
+## Key Principles (Stable)
+
+**Container properties** (set on the `<utu:AutoLayout>` element itself):
+
+- `Orientation` — Horizontal or Vertical (primary axis)
+- `Spacing` — gap between children (like Figma auto-layout spacing)
+- `Justify` — SpaceBetween distribution
+- `PrimaryAxisAlignment` — alignment on the primary axis (`Start`, `Center`, `End`, `Stretch`)
+- `CounterAxisAlignment` — alignment on the cross axis (`Start`, `Center`, `End`, `Stretch`)
+- `Padding` — Figma-anchor-style padding (`Thickness`)
+
+**Per-child attached properties** (set on children of an `AutoLayout`, **note: NOT the same names as the container properties**):
+
+- `utu:AutoLayout.PrimaryAlignment` — override on primary axis (`Auto` or `Stretch`)
+- `utu:AutoLayout.CounterAlignment` — override on counter axis (`Start`, `Center`, `End`, `Stretch`) — **`CounterAlignment`, NOT `CounterAxisAlignment`**
+- `utu:AutoLayout.PrimaryLength` — fixed size along orientation axis (`double`)
+- `utu:AutoLayout.CounterLength` — fixed size perpendicular to orientation (`double`)
+- `utu:AutoLayout.IsIndependentLayout` — absolute positioning (`bool`)
+
+There is **no** `AutoLayout.Counterpart`, no `AutoLayout.SetCounterAxisAlignment(...)`, no `AutoLayout.Align`, no `AutoLayout.MainAxis`, no `AutoLayout.CrossAxis`. If unsure, the canonical surface is the table above — do not invent member names.
+
+**XAML namespace:** `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-responsive]] — Responsive layout based on screen size

--- a/plugins/uno-platform-studio/skills/uno-toolkit-card/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-card/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: uno-toolkit-card
+description: "Use CardContentControl for elevated, filled, or outlined card containers."
+when_to_use: "ALWAYS use this skill when building any card-like UI — elevated, filled, or outlined containers. ALWAYS use `CardContentControl` — never use `Card` (it has rigid predefined slots that limit layout flexibility). ALWAYS use this skill instead of creating a `Border` used as a card (with `CornerRadius` combined with `Background`, `Padding`, or `BorderBrush`) — `CardContentControl` provides proper styling, elevation, and theming out of the box. Custom card layouts with full control over content via `ContentTemplate`."
+metadata:
+  author: uno-platform
+  version: "3.6"
+  category: toolkit
+---
+
+# Uno Toolkit CardContentControl — Agent Skill
+
+## Critical Rules
+
+- **NEVER use `Card`** — always use `CardContentControl`. The `Card` control has rigid predefined slots (HeaderContent, SubHeaderContent, AvatarContent, etc.) that constrain layout. `CardContentControl` gives full layout freedom via `ContentTemplate`.
+- **NEVER use `Border` with `CornerRadius` to wrap content.** This is the most common Border anti-pattern in generated XAML and the parser flags it as `GRD1102`. Always use `CardContentControl` instead — it provides correct elevation, corner radius, theming, and accessibility automatically.
+
+### Anti-pattern detection (matches `GRD1102`)
+
+If you find yourself writing a `<Border>` that meets **all** of the following, stop and rewrite it as `utu:CardContentControl`:
+
+1. The `Border` has children (it is **not** self-closing).
+2. It sets `CornerRadius` to a non-zero value.
+3. It sets at least one of: `Background`, `BorderBrush` (with non-zero `BorderThickness`), or non-zero `Padding`.
+
+That's a card. `<Border CornerRadius="8" Background="..." Padding="16">…</Border>` is a card written the wrong way.
+
+```xml
+<!-- WRONG: Border-as-card (the parser will report GRD1102) -->
+<Border CornerRadius="8"
+        Background="{ThemeResource SurfaceBrush}"
+        Padding="16">
+    <StackPanel Spacing="8">
+        <TextBlock Text="Title"/>
+        <TextBlock Text="Body"/>
+    </StackPanel>
+</Border>
+
+<!-- CORRECT: utu:CardContentControl -->
+<utu:CardContentControl Style="{StaticResource ElevatedCardContentControlStyle}">
+    <utu:CardContentControl.ContentTemplate>
+        <DataTemplate>
+            <StackPanel Padding="16" Spacing="8">
+                <TextBlock Text="Title"/>
+                <TextBlock Text="Body"/>
+            </StackPanel>
+        </DataTemplate>
+    </utu:CardContentControl.ContentTemplate>
+</utu:CardContentControl>
+```
+
+### When `Border` is still correct
+
+`Border` is the right choice for: dividers (`<Border Height="1" Background="..."/>`), thin separators, simple background fills with no rounded corners, image/content clipping with `CornerRadius` alone (no `Background`/`Padding`/`BorderBrush+BorderThickness`), and layout primitives **inside** a `ControlTemplate`. The grader specifically targets the *card-shaped* combination above; plain layout borders are unaffected.
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the CardContentControl Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit CardContentControl elevated filled outlined")
+```
+
+Primary documentation page:
+- **Card & CardContentControl**: `external/uno.toolkit.ui/doc/controls/CardAndCardContentControl.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/CardAndCardContentControl.md")
+```
+
+### Step 2: For How-To / Walkthrough
+
+```
+uno_platform_docs_search("CardContentControl howto walkthrough custom template")
+```
+
+Key page:
+- **Card How-To**: `external/uno.toolkit.ui/doc/controls/walkthroughs/Card-and-CardContentControl.howto.md`
+
+## Key Principles (Stable)
+
+- **`CardContentControl`** — fully custom layout via `ContentTemplate`. This is the only card control you should use.
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+- Do NOT use `Card` — it has predefined slots that limit layout flexibility
+- Do NOT use `Border` as a card (`CornerRadius` + `Background`/`Padding`/`BorderBrush`) — the parser reports this as `GRD1102`; use `CardContentControl` instead
+
+## Critical: Content Binding in DataTemplates
+
+When `CardContentControl` is used **inside** an `ItemsRepeater`, `ListView`, or any other `DataTemplate`, you **MUST** set `Content="{Binding}"` on the `CardContentControl`. Without this, the inner `ContentTemplate > DataTemplate` has **no DataContext** and all bindings inside it resolve to null (rendering the card empty/invisible).
+
+### Rules
+
+- **ALWAYS** set `Content="{Binding}"` on `CardContentControl` when it appears inside a `DataTemplate`
+- **NEVER** use indexed bindings (e.g. `{Binding Items[0].Label}`) inside card templates — use `ItemsSource` with a nested `ItemsRepeater` instead
+- The `ContentTemplate`'s inner `DataTemplate` inherits its DataContext **only** from the `Content` property — if `Content` is not bound, the inner template has no data
+
+### Correct pattern
+
+```xml
+<DataTemplate x:DataType="local:MenuItem">
+  <utu:CardContentControl Style="{StaticResource FilledCardContentControlStyle}"
+                           Content="{Binding}">
+    <utu:CardContentControl.ContentTemplate>
+      <DataTemplate>
+        <TextBlock Text="{Binding Label}" />
+      </DataTemplate>
+    </utu:CardContentControl.ContentTemplate>
+  </utu:CardContentControl>
+</DataTemplate>
+```
+
+### Wrong pattern (missing Content binding)
+
+```xml
+<!-- ❌ WRONG: No Content="{Binding}" — inner DataTemplate has no DataContext -->
+<DataTemplate x:DataType="local:MenuItem">
+  <utu:CardContentControl Style="{StaticResource FilledCardContentControlStyle}">
+    <utu:CardContentControl.ContentTemplate>
+      <DataTemplate>
+        <TextBlock Text="{Binding Label}" />  <!-- This resolves to null! -->
+      </DataTemplate>
+    </utu:CardContentControl.ContentTemplate>
+  </utu:CardContentControl>
+</DataTemplate>
+```
+
+## Sizing — `CardContentControl` does NOT stretch by default
+
+`CardContentControl` sizes to its content. It will **not** fill the available width or height of its parent on its own, even inside a `Grid` cell or `StackPanel` slot that has space to spare. If you need the card to take all available space (a hero card, a full-width row, a column-filling pane), set the alignment **explicitly** on the `CardContentControl` itself:
+
+```xml
+<!-- Card fills its grid cell horizontally and vertically -->
+<utu:CardContentControl Grid.Row="0"
+                        Style="{StaticResource ElevatedCardContentControlStyle}"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch">
+    <utu:CardContentControl.ContentTemplate>
+        <DataTemplate>
+            <Grid Padding="16">
+                <!-- ... -->
+            </Grid>
+        </DataTemplate>
+    </utu:CardContentControl.ContentTemplate>
+</utu:CardContentControl>
+```
+
+Rules of thumb:
+
+- **Full-width row card** (e.g. summary card across a page): `HorizontalAlignment="Stretch"`.
+- **Column- or pane-filling card** (e.g. a card that should fill a `*` row in a `Grid`): `HorizontalAlignment="Stretch"` **and** `VerticalAlignment="Stretch"`.
+- **Card inside an `ItemsRepeater`/`ListView` item template that should fill the item slot**: `HorizontalAlignment="Stretch"`.
+- **Compact / chip-style card sized to its content**: leave alignment unset (default behavior).
+
+Setting `Width`/`Height` on the inner content of the `ContentTemplate` will not stretch the card — the alignment must be set on the `CardContentControl` element.
+
+## Style Variants
+
+`CardContentControl` exposes three semantic style keys. Each design-theme provides its own concrete look; the key names are shared across themes.
+
+| Style | When to use |
+|-------|-------------|
+| `ElevatedCardContentControlStyle` | Subtle z-axis elevation; default choice for surfaced content |
+| `FilledCardContentControlStyle` | Background tint, no elevation; use on busy backgrounds |
+| `OutlinedCardContentControlStyle` | Stroke instead of fill/elevation; secondary content |
+
+## Related Skills
+
+- [[uno-toolkit-shadowcontainer]] — Custom shadow effects
+- [[uno-toolkit-lightweight-styling]] — Resource key overrides for cards

--- a/plugins/uno-platform-studio/skills/uno-toolkit-chip/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-chip/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: uno-toolkit-chip
+description: "Use Chip and ChipGroup for selection, filtering, or action triggers. Supports Assist, Input, Filter, and Suggestion chip styles."
+when_to_use: "Use when building filter bars, tag input, multi-select pills, or suggestion chips — the Assist, Input, Filter, and Suggestion chip patterns. `ChipGroup` handles single or multi-selection; chips support leading icons and a remove button."
+metadata:
+  author: uno-platform
+  version: "2.5"
+  category: toolkit
+---
+
+# Uno Toolkit Chip — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Chip Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit Chip ChipGroup filter assist input suggestion")
+```
+
+Primary documentation page:
+- **Chip & ChipGroup**: `external/uno.toolkit.ui/doc/controls/ChipAndChipGroup.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/ChipAndChipGroup.md")
+```
+
+### Step 2: For How-To / Walkthrough
+
+```
+uno_platform_docs_search("Chip ChipGroup howto walkthrough selection filter")
+```
+
+## Key Principles (Stable)
+
+- `Chip` is derived from `ToggleButton` — can be checked/unchecked
+- Styles: `AssistChipStyle`, `InputChipStyle`, `FilterChipStyle`, `SuggestionChipStyle`
+- `ChipGroup` manages a collection of chips with `SelectionMode` (Single, Multiple, None)
+- `CanRemove="True"` enables a remove button on the chip
+- Icon support via `Icon` property
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-selector-extensions]] — Selection behavior extensions

--- a/plugins/uno-platform-studio/skills/uno-toolkit-command-extensions/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-command-extensions/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: uno-toolkit-command-extensions
+description: "Attached properties (`CommandExtensions.Command`, `CommandExtensions.CommandParameter`) that bind controls without a built-in `Command` to MVVM commands."
+when_to_use: "Use when a UI event (Enter in `TextBox`, item click in `ListView`, `ToggleSwitch` toggle, `NavigationViewItem` invocation, any `UIElement` tap) must invoke an MVVM command without code-behind event handlers."
+metadata:
+  author: uno-platform
+  version: "2.5"
+  category: toolkit
+---
+
+# Uno Toolkit Command Extensions — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the CommandExtensions Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit CommandExtensions command TextBox enter ToggleSwitch ListView tap")
+```
+
+Primary documentation pages:
+- **CommandExtensions (Chefs)**: `external/uno.chefs/doc/toolkit/CommandExtensions.md`
+- **Command Extensions helper**: search for `CommandExtensions` in toolkit helpers
+
+Fetch the Chefs page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.chefs/doc/toolkit/CommandExtensions.md")
+```
+
+### Step 2: For Reference Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit CommandExtensions attached property Command CommandParameter")
+```
+
+## Critical Rules
+
+- There is **no `CommandTrigger` attached property**. `utu:CommandExtensions.Command="{Binding ...}"` alone is sufficient — the trigger event is determined automatically by the control type (Enter on `TextBox`/`PasswordBox`, item click on `ListView`, toggle on `ToggleSwitch`, invocation on `NavigationView`, tap on any `UIElement`). Do not invent a separate trigger property.
+- `Command` on `ListView` requires `IsItemClickEnabled="True"` to fire.
+
+## Key Principles (Stable)
+
+- `utu:CommandExtensions.Command="{Binding MyCommand}"` — attaches a command
+- `utu:CommandExtensions.CommandParameter` — optional parameter
+- Supported controls: TextBox (enter key), PasswordBox, ToggleSwitch, ListView, NavigationView, ItemsRepeater, any UIElement (tap)
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-input-extensions]] — Input field focus flow
+- [[uno-toolkit-itemsrepeater-extensions]] — ItemsRepeater selection

--- a/plugins/uno-platform-studio/skills/uno-toolkit-csharp-markup/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-csharp-markup/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: uno-toolkit-csharp-markup
+description: "Use C# Markup with Uno Toolkit controls instead of XAML. Setup, NuGet packages, and fluent API patterns."
+when_to_use: "Use when the project uses C# Markup instead of XAML and needs the Toolkit's fluent extension methods, setting up the `Uno.Toolkit.WinUI.Markup` NuGet package, applying Toolkit styles, extensions, and helpers in C# Markup, or converting existing XAML Toolkit usage to C# Markup."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit C# Markup — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the C# Markup Toolkit Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit C# Markup fluent API setup NuGet package")
+```
+
+Primary documentation pages:
+- **Toolkit C# Markup**: `external/uno.toolkit.ui/doc/getting-started.md`
+- **Material Toolkit C# Markup**: `external/uno.toolkit.ui/doc/material-getting-started.md`
+- **Chefs C# Markup Toolkit Tutorial**: `external/uno.extensions/doc/Learn/Markup/HowTo-CustomMarkupProject-Toolkit.md`
+
+Fetch the Chefs tutorial:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Markup/HowTo-CustomMarkupProject-Toolkit.md")
+```
+
+## Key Principles (Stable)
+
+- Add `Uno.Toolkit.WinUI.Markup` NuGet package
+- For Material: add `Uno.Toolkit.WinUI.Material.Markup` NuGet package
+- Fluent API: `new Card().Style(Theme.Card.Styles.Elevated)`
+- Same controls and helpers, expressed in C# instead of XAML
+
+## Related Skills
+
+- [[uno-toolkit-getting-started]] — Base Toolkit setup
+- [[uno-themes-material]] — Material C# Markup

--- a/plugins/uno-platform-studio/skills/uno-toolkit-cupertino-theme/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-cupertino-theme/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: uno-toolkit-cupertino-theme
+description: "Configure Uno Cupertino Toolkit with CupertinoToolkitTheme for iOS-style Toolkit controls."
+when_to_use: "Use when targeting iOS-styled UI and replacing `MaterialToolkitTheme` with `CupertinoToolkitTheme` in App.xaml, implementing Apple Human Interface Guidelines styling, or applying the Cupertino design system to Toolkit controls."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit Cupertino Theme — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Cupertino Toolkit Documentation
+
+```
+uno_platform_docs_search("Uno Cupertino Toolkit CupertinoToolkitTheme getting started")
+```
+
+Primary documentation page:
+- **Cupertino Toolkit Getting Started**: `external/uno.toolkit.ui/doc/cupertino-getting-started.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/cupertino-getting-started.md")
+```
+
+## Key Principles (Stable)
+
+- `CupertinoToolkitTheme` is the unified approach for Cupertino-styled Toolkit controls
+- Place in App.xaml `<Application.Resources>`
+- Requires `Toolkit` in `<UnoFeatures>`
+- Cupertino and Material themes are mutually exclusive
+
+## Related Skills
+
+- [[uno-toolkit-getting-started]] — Base Toolkit setup
+- [[uno-toolkit-material-theme]] — Material alternative

--- a/plugins/uno-platform-studio/skills/uno-toolkit-divider/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-divider/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: uno-toolkit-divider
+description: "Use Divider control to create visual separators between content sections. A thin line with optional subheader text."
+when_to_use: "Use when separating list, form, or settings sections with a thin rule, with or without a subheader label. Supports horizontal and vertical orientations and lightweight styling via resource keys."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit Divider — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Divider Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit Divider separator thin line subheader")
+```
+
+Primary documentation page:
+- **Divider**: `external/uno.toolkit.ui/doc/controls/Divider.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/Divider.md")
+```
+
+## Key Principles (Stable)
+
+- Simple thin line separator
+- Optional `SubHeader` text property
+- Supports lightweight styling via resource keys
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-lightweight-styling]] — Customizing divider appearance

--- a/plugins/uno-platform-studio/skills/uno-toolkit-drawer/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-drawer/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: uno-toolkit-drawer
+description: "Use DrawerControl for swipe-gesture navigation drawers and DrawerFlyoutPresenter for bottom/side sheet flyouts."
+when_to_use: "Use when adding swipe-to-open side drawers, bottom sheets, or modal flyout panels. `DrawerControl` for a full drawer layout with main + slide-in content; `DrawerFlyoutPresenter` for gesture-enabled `Flyout` presenters."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit Drawer — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Drawer Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit DrawerControl DrawerFlyoutPresenter swipe sheet")
+```
+
+Primary documentation page:
+- **DrawerControl**: `external/uno.toolkit.ui/doc/controls/DrawerControl.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/DrawerControl.md")
+```
+
+### Step 2: For DrawerFlyoutPresenter
+
+If the user needs gesture-enabled flyouts:
+
+```
+uno_platform_docs_search("Uno Toolkit DrawerFlyoutPresenter flyout bottom sheet gesture")
+```
+
+## Key Principles (Stable)
+
+- `DrawerControl` has a main content area and a drawer that slides in
+- `DrawerOpenDirection` — Left, Right, Up, Down
+- `IsOpen` property controls drawer state (bindable)
+- `DrawerFlyoutPresenter` — adds swipe gesture support to standard Flyouts
+- `DrawerLength` — size of the drawer
+- Supports light dismiss (tap outside to close)
+
+## Related Skills
+
+- [[uno-navigation-dialogs]] — Dialog/flyout via navigation

--- a/plugins/uno-platform-studio/skills/uno-toolkit-extendedsplashscreen/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-extendedsplashscreen/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: uno-toolkit-extendedsplashscreen
+description: "Use ExtendedSplashScreen to display a loading screen that extends the native splash screen appearance."
+when_to_use: "Use when extending the native splash screen during app initialization, showing loading progress during startup, custom startup loading content, or android requires `Init()` call in MainActivity."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: toolkit
+---
+
+# Uno Toolkit ExtendedSplashScreen — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the ExtendedSplashScreen Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit ExtendedSplashScreen splash loading startup Init")
+```
+
+Primary documentation page:
+- **ExtendedSplashScreen**: search results will provide the control page
+
+Fetch results and look for the control documentation:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls-styles.md")
+```
+
+Search for ExtendedSplashScreen in the controls list.
+
+### Step 2: For Navigation Integration
+
+ExtendedSplashScreen often works with Navigation Extensions for Shell startup:
+
+See the `uno-navigation-setup` skill.
+
+## Key Principles (Stable)
+
+- Based on `LoadingView` — shows native splash image with custom loading content
+- Requires `Init()` call on Android in `MainActivity.OnCreate`
+- Do NOT use `Region.Attached="True"` inside ExtendedSplashScreen content
+- Content is shown on top of the native splash screen image
+- Loading screen visuals (splash image, background color) are primarily controlled by **Resizetizer** configuration
+
+## Related Skills
+
+- [[uno-toolkit-loadingview]] — Base loading control
+- [[uno-navigation-setup]] — Navigation host setup

--- a/plugins/uno-platform-studio/skills/uno-toolkit-flipview-extensions/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-flipview-extensions/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: uno-toolkit-flipview-extensions
+description: "Use FlipViewExtensions to add navigation buttons to FlipView. Auto-shows Previous/Next arrows for desktop."
+when_to_use: "Use when a `FlipView` needs Previous/Next arrow buttons on desktop (the default touch swipe is mouse-hostile). Buttons auto-show on desktop and can be styled via attached properties."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit FlipView Extensions — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the FlipView Extensions Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit FlipView extensions navigation buttons previous next arrows")
+```
+
+### Step 2: For Reference
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls-styles.md")
+```
+
+Look for FlipViewExtensions in the helpers section.
+
+## Key Principles (Stable)
+
+- Shows Previous/Next navigation arrows on FlipView
+- Buttons auto-show on hover for desktop
+- Customizable button templates via default chevron styles
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- (standalone helper, no primary dependencies)

--- a/plugins/uno-platform-studio/skills/uno-toolkit-getting-started/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-getting-started/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: uno-toolkit-getting-started
+description: "Install and configure Uno Toolkit library in Uno Platform applications."
+when_to_use: "Use when setting up Uno Toolkit in a new or existing project, adding `<UnoFeatures>Toolkit</UnoFeatures>` to a project, configuring ToolkitResources or MaterialToolkitTheme in App.xaml, or understanding Toolkit NuGet package requirements."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: toolkit
+---
+
+# Uno Toolkit Getting Started — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Getting Started Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit getting started install UnoFeatures ToolkitResources")
+```
+
+Primary documentation pages:
+- **Getting Started (base Toolkit)**: `external/uno.toolkit.ui/doc/getting-started.md`
+- **Material Toolkit Getting Started**: `external/uno.toolkit.ui/doc/material-getting-started.md`
+
+Fetch the getting started page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/getting-started.md")
+```
+
+### Step 2: For Material Design Toolkit
+
+If user needs Material Design styled toolkit controls:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/material-getting-started.md")
+```
+
+### Step 3: For Available Controls and Helpers
+
+To see the full list of Toolkit controls and helpers:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls-styles.md")
+```
+
+## Key Principles (Stable)
+
+- Add `Toolkit` to `<UnoFeatures>` in the project file
+- For Material styling, use `MaterialToolkitTheme` in App.xaml (replaces separate MaterialTheme + ToolkitResources)
+- For Cupertino styling, use `CupertinoToolkitTheme`
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+- CLI: `dotnet new unoapp -o MyApp -toolkit` to create a new project with Toolkit
+
+## Related Skills
+
+- [[uno-toolkit-material-theme]] — MaterialToolkitTheme configuration
+- [[uno-toolkit-cupertino-theme]] — CupertinoToolkitTheme configuration
+- [[uno-themes-material]] — Material theme installation

--- a/plugins/uno-platform-studio/skills/uno-toolkit-input-extensions/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-input-extensions/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: uno-toolkit-input-extensions
+description: "Use InputExtensions for form input UX improvements including auto-focus next field, auto-dismiss keyboard, and custom return key types."
+when_to_use: "Use when implementing forms that auto-advance focus on Enter, dismiss the keyboard on completion, or set platform-specific return key types (Next, Done, Search) — typically login forms or multi-field input sequences on mobile."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit Input Extensions — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the InputExtensions Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit InputExtensions auto focus next dismiss keyboard return type")
+```
+
+Primary documentation pages:
+- **Input Extensions**: `external/uno.toolkit.ui/doc/helpers/Input-extensions.md`
+- **Input Extensions How-To**: `external/uno.toolkit.ui/doc/helpers/walkthroughs/input-extensions.howto.md`
+
+Fetch the helper reference:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/helpers/Input-extensions.md")
+```
+
+### Step 2: For Login Form Example
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/helpers/walkthroughs/input-extensions.howto.md")
+```
+
+## Key Principles (Stable)
+
+- `utu:InputExtensions.AutoFocusNext="True"` — moves focus to next field on Enter
+- `utu:InputExtensions.AutoDismiss="True"` — dismisses keyboard on last field Enter
+- `utu:InputExtensions.ReturnType="Next|Done|Search|Send|Go"` — mobile keyboard button
+- Essential for login forms and any multi-field input
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-safearea]] — Keyboard-aware safe area for forms
+- [[uno-toolkit-command-extensions]] — Command on TextBox enter

--- a/plugins/uno-platform-studio/skills/uno-toolkit-itemsrepeater-extensions/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-itemsrepeater-extensions/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: uno-toolkit-itemsrepeater-extensions
+description: "Attached properties (`utu:ItemsRepeaterExtensions.SelectionMode`, `.SelectedItem`, `.SelectedItems`, `.SelectedIndex`, `.SelectedIndexes`) that add selection and incremental loading to `ItemsRepeater`."
+when_to_use: "Use when `ItemsRepeater` needs selection or fetch-on-scroll — `ItemsRepeater` itself has no built-in `SelectionMode` / `SelectedItem`, so the Toolkit's attached properties are the canonical way to add them. Pairs with `ISupportIncrementalLoading` on the data source for automatic page loading."
+metadata:
+  author: uno-platform
+  version: "2.5"
+  category: toolkit
+---
+
+# Uno Toolkit ItemsRepeater Extensions — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the ItemsRepeater Extensions Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit ItemsRepeater extensions selection SelectedItem incremental loading")
+```
+
+Primary documentation:
+
+```
+uno_platform_docs_search("ItemsRepeaterExtensions SelectedItem SelectedItems SelectionMode incremental")
+```
+
+### Step 2: For Controls Reference
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls-styles.md")
+```
+
+Look for ItemsRepeaterExtensions in the helpers section.
+
+## Key Principles (Stable)
+
+- `utu:ItemsRepeaterExtensions.SelectedItem` — single selected item (bindable)
+- `utu:ItemsRepeaterExtensions.SelectedIndex` — single selection index (bindable)
+- `utu:ItemsRepeaterExtensions.SelectedItems` — multiple selected items (bindable)
+- `utu:ItemsRepeaterExtensions.SelectedIndexes` — multiple selection indexes (bindable)
+- `utu:ItemsRepeaterExtensions.SelectionMode` — Single, Multiple, None
+- Supports `ISupportIncrementalLoading` for automatic data fetching on scroll
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-selector-extensions]] — Selection on Selector-based controls
+- [[uno-toolkit-command-extensions]] — Command on ItemsRepeater tap

--- a/plugins/uno-platform-studio/skills/uno-toolkit-lightweight-styling/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-lightweight-styling/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: uno-toolkit-lightweight-styling
+description: "Apply lightweight styling to Uno Toolkit controls by overriding resource keys. Change colors, fonts, spacing without custom styles."
+when_to_use: "Use when customising Toolkit control appearance by overriding resource keys (colors, fonts, spacing) rather than rewriting templates. Overrides may live at app, page, or per-control scope; the main task is finding the right resource key in the naming pattern."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit Lightweight Styling — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Lightweight Styling Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit lightweight styling resource keys override controls")
+```
+
+Primary documentation page:
+- **Toolkit Lightweight Styling**: `external/uno.toolkit.ui/doc/lightweight-styling.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/lightweight-styling.md")
+```
+
+### Step 2: For Specific Control Resource Keys
+
+Each control's documentation page lists its resource keys. Search for the specific control:
+
+```
+uno_platform_docs_search("Uno Toolkit [ControlName] lightweight styling resource keys")
+```
+
+## Key Principles (Stable)
+
+- Override resource keys at App, Page, or Control level
+- Resource keys follow naming patterns: `{ControlName}{State}{Property}`
+- Control-level overrides use `<Control.Resources>` or `ResourceExtensions`
+- No need to redefine entire styles/templates
+- Each control's doc page lists available resource keys
+
+## Related Skills
+
+- [[uno-toolkit-resource-extensions]] — Per-control resource dictionary
+- [[uno-themes-material]] — Material design lightweight styling

--- a/plugins/uno-platform-studio/skills/uno-toolkit-loadingview/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-loadingview/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: uno-toolkit-loadingview
+description: "Use LoadingView to display loading indicators while async operations execute. Binds to ILoadable sources like AsyncCommand."
+when_to_use: "Use when a view must show a spinner or skeleton while an `IAsyncCommand`, `IFeed`, or `IState` is in flight, binding `LoadingView` to any `ILoadable` source, composing multiple in-flight operations via `CompositeLoadableSource`, or toggling the loading visual automatically as commands execute."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit LoadingView — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the LoadingView Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit LoadingView loading indicator ILoadable AsyncCommand")
+```
+
+Primary documentation page:
+- **LoadingView**: `external/uno.toolkit.ui/doc/controls/LoadingView.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/LoadingView.md")
+```
+
+### Step 2: For How-To / Walkthrough
+
+```
+uno_platform_docs_search("LoadingView howto walkthrough AsyncCommand loading")
+```
+
+## Key Principles (Stable)
+
+- `Source` property binds to an `ILoadable` (like `AsyncCommand`)
+- Loading content is displayed when the source is busy
+- `CompositeLoadableSource` combines multiple ILoadable sources
+- `LoadingContent` — custom content shown during loading (default is ProgressRing)
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-progress-extensions]] — ProgressBar/ProgressRing loading binding
+- [[uno-toolkit-extendedsplashscreen]] — App startup loading

--- a/plugins/uno-platform-studio/skills/uno-toolkit-material-theme/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-material-theme/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: uno-toolkit-material-theme
+description: "Configure Uno Material Toolkit with MaterialToolkitTheme for Material Design 3 styled Toolkit controls. Includes color and font customization."
+when_to_use: "Use when wiring a Material Design 3 styled Uno Toolkit shell. `MaterialToolkitTheme` in App.xaml replaces the separate `MaterialTheme` + `ToolkitResources` pair and accepts color and font customisation in its constructor."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit Material Theme — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Material Toolkit Getting Started
+
+```
+uno_platform_docs_search("Uno Material Toolkit MaterialToolkitTheme configuration App.xaml")
+```
+
+Primary documentation page:
+- **Material Toolkit Getting Started**: `external/uno.toolkit.ui/doc/material-getting-started.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/material-getting-started.md")
+```
+
+### Step 2: For Color/Font Customization
+
+Customization is done via `MaterialToolkitTheme` properties:
+
+```
+uno_platform_docs_search("MaterialToolkitTheme color font override customize palette")
+```
+
+## Key Principles (Stable)
+
+- `MaterialToolkitTheme` is the unified approach — replaces separate `MaterialTheme` + `ToolkitResources`
+- Place in App.xaml `<Application.Resources>` section
+- Supports `ColorOverrideSource` and `FontOverrideSource` for customization
+- Requires `Toolkit` in `<UnoFeatures>`
+
+## Related Skills
+
+- [[uno-toolkit-getting-started]] — Base Toolkit setup
+- [[uno-themes-material]] — Material theme (non-Toolkit): installation, color palette customization, typography, control styles

--- a/plugins/uno-platform-studio/skills/uno-toolkit-navigationbar/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-navigationbar/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: uno-toolkit-navigationbar
+description: "Page-level app bar with title, back button, and action items; renders natively on iOS and Android."
+when_to_use: "Use when adding a page-level app bar with title, back button (`MainCommand`), and `AppBarButton` actions in `PrimaryCommands` / `SecondaryCommands`. Renders as XAML on Windows and as the native bar on iOS / Android."
+metadata:
+  author: uno-platform
+  version: "2.5"
+  category: toolkit
+---
+
+# Uno Toolkit NavigationBar — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the NavigationBar Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit NavigationBar app bar MainCommand PrimaryCommands")
+```
+
+Primary documentation page:
+- **NavigationBar**: `external/uno.toolkit.ui/doc/controls/NavigationBar.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/NavigationBar.md")
+```
+
+### Step 2: For Chefs Examples
+
+```
+uno_platform_docs_search("NavigationBar Chefs app example navigation back")
+```
+
+## Critical Rules
+
+- **`MainCommand` is an `AppBarButton`** — there is no dedicated `NavigationBarMainCommand` type. Use `<utu:NavigationBar.MainCommand><AppBarButton Icon="Back" Command="{Binding GoBackCommand}"/></utu:NavigationBar.MainCommand>` (or equivalent attribute form). The same `AppBarButton` type is used for `PrimaryCommands` and `SecondaryCommands` items.
+
+## Key Principles (Stable)
+
+- `MainCommand` — the back-button slot; an `AppBarButton` instance
+- `PrimaryCommands` — action `AppBarButton`s displayed on the right
+- `SecondaryCommands` — overflow `AppBarButton`s in the overflow menu
+- Two rendering modes: `Windows` (XAML drawn) and `Native` (platform AppBar on iOS/Android)
+- Content property is the title
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-safearea]] — Safe area insets with NavigationBar
+- [[uno-navigation-code]] — Navigation integration

--- a/plugins/uno-platform-studio/skills/uno-toolkit-progress-extensions/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-progress-extensions/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: uno-toolkit-progress-extensions
+description: "Use ProgressExtensions to toggle all ProgressRing and ProgressBar controls under a sub-visual-tree with a single binding."
+when_to_use: "Use when toggling every `ProgressRing` and `ProgressBar` inside a subtree with one boolean binding, instead of binding each control individually."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit Progress Extensions — Agent Skill
+
+## Workflow
+
+### Step 1: Fetch the ProgressExtensions Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit ProgressExtensions progress bar ring ILoadable async command")
+```
+
+Primary documentation:
+
+```
+uno_platform_docs_search("ProgressExtensions IsActive source loadable progress")
+```
+
+## Key Principles (Stable)
+
+- `utu:ProgressExtensions.IsExecuting` — attached boolean property on a parent element that toggles all `ProgressRing` and `ProgressBar` controls in its sub-visual-tree
+- Acts on `ProgressRing.IsActive` and `ProgressBar.IsIndeterminate` properties of descendant controls
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-loadingview]] — LoadingView for full-content loading states

--- a/plugins/uno-platform-studio/skills/uno-toolkit-resource-extensions/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-resource-extensions/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: uno-toolkit-resource-extensions
+description: "Use ResourceExtensions to apply ResourceDictionary directly to control styles for lightweight styling. Enables visual variants without page-level resources."
+when_to_use: "Use when applying a `ResourceDictionary` directly to a single control so it picks up a visual variant without declaring resources at page level — typically per-control color or brush overrides, or shared-base-style variants."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit Resource Extensions — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the ResourceExtensions Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit ResourceExtensions ResourceDictionary style lightweight inline")
+```
+
+Primary documentation pages:
+- **ResourceExtensions (Chefs)**: `external/uno.chefs/doc/toolkit/ResourceExtensions.md`
+
+Fetch the Chefs page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.chefs/doc/toolkit/ResourceExtensions.md")
+```
+
+### Step 2: For Reference Documentation
+
+```
+uno_platform_docs_search("ResourceExtensions Resources attached property dictionary override")
+```
+
+## Key Principles (Stable)
+
+- `utu:ResourceExtensions.Resources` — attaches a ResourceDictionary to a control
+- Enables per-control resource key overrides without nesting in page resources
+- Great for creating multiple visual variants of the same control
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-lightweight-styling]] — General lightweight styling approach
+- [[uno-themes-material]] — Material lightweight styling

--- a/plugins/uno-platform-studio/skills/uno-toolkit-responsive/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-responsive/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: uno-toolkit-responsive
+description: "Screen-size-based UI adaptation via the `ResponsiveExtension` markup extension and `ResponsiveView` control."
+when_to_use: "Use when one layout must adapt to phone, tablet, or desktop, when XAML needs per-breakpoint property values (font size, orientation, padding, margin), or when an entire view subtree differs by screen size. `ResponsiveExtension` swaps property values; `ResponsiveView` swaps entire `DataTemplate`s. Custom breakpoints via `ResponsiveLayout`."
+metadata:
+  author: uno-platform
+  version: "2.5"
+  category: toolkit
+---
+
+# Uno Toolkit Responsive — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the ResponsiveExtension Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit ResponsiveExtension responsive screen size breakpoints property")
+```
+
+Primary documentation pages:
+- **ResponsiveExtension**: `external/uno.toolkit.ui/doc/helpers/responsive-extension.md`
+- **ResponsiveView**: `external/uno.toolkit.ui/doc/controls/ResponsiveView.md`
+
+Fetch ResponsiveExtension:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/helpers/responsive-extension.md")
+```
+
+### Step 2: For ResponsiveView (Template Switching)
+
+Fetch ResponsiveView for swapping entire layouts:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/ResponsiveView.md")
+```
+
+### Step 3: For How-To Examples
+
+```
+uno_platform_docs_search("ResponsiveExtension howto walkthrough responsive layout breakpoints")
+```
+
+Key page:
+- **ResponsiveExtension How-To**: `external/uno.toolkit.ui/doc/helpers/walkthroughs/responsive-extension.howto.md`
+
+## Critical Rules
+
+- **`ResponsiveExtension` must be used as a markup extension** — `{utu:Responsive Narrow=Red, Wide=Blue}` — never as a XAML element (`<utu:ResponsiveExtension .../>`). The XAML engine parses the breakpoint values as strings and performs type conversion through `MarkupExtension.ProvideValue`, which is only available in markup-extension form.
+- On Windows UWP targets, `ResponsiveExtension` only works with `string` value properties due to a `MarkupExtension.ProvideValue(IXamlServiceProvider)` limitation. For non-string properties on Windows UWP, declare the values as resources and pass them via `{StaticResource ...}` (see Uno Toolkit docs).
+
+## Key Principles (Stable)
+
+- **ResponsiveExtension** — sets property values per breakpoint (Narrow, Normal, Wide, etc.) via the `{utu:Responsive ...}` markup-extension form
+- **ResponsiveView** — swaps entire DataTemplates per breakpoint (used as an element)
+- Default breakpoints: Narrowest (150), Narrow (300), Normal (600), Wide (800), Widest (1080)
+- Custom breakpoints via `ResponsiveLayout` resource
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-navigation-responsive-shell]] — Responsive navigation shells

--- a/plugins/uno-platform-studio/skills/uno-toolkit-safearea/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-safearea/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: uno-toolkit-safearea
+description: "Use SafeArea to keep content within visible screen bounds, avoiding notches, status bars, and on-screen keyboards. Essential for mobile forms."
+when_to_use: "Use when laying out forms, footers, or bottom navigation that must clear iOS home-indicator, Android gesture bar, device notches, rounded corners, the status bar, or the on-screen keyboard. CRITICAL for any mobile page with a `TextBox` or `PasswordBox`. Apply via the `<SafeArea>` control or the `SafeArea.Insets` attached property."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit SafeArea — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the SafeArea Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit SafeArea insets notch keyboard mobile form")
+```
+
+Primary documentation pages:
+- **SafeArea Control**: `external/uno.toolkit.ui/doc/controls/SafeArea.md`
+- **SafeArea How-To**: `external/uno.toolkit.ui/doc/controls/walkthroughs/SafeArea.howto.md`
+
+Fetch the how-to:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/walkthroughs/SafeArea.howto.md")
+```
+
+### Step 2: For Detailed Properties Reference
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/SafeArea.md")
+```
+
+## Key Principles (Stable)
+
+- **ALWAYS use SafeArea** on pages with TextBox/PasswordBox on mobile — keyboard WILL obscure inputs otherwise
+- Two usage modes: `<SafeArea Insets="...">` (control) or `utu:SafeArea.Insets="..."` (attached property)
+- `Insets` values: `Left`, `Top`, `Right`, `Bottom`, `SoftInput` (keyboard), or combinations
+- `Mode` — `Padding` (default, adds padding) or `InsetMode.Margin` (adds margin)
+- For keyboard: use `Insets="SoftInput"` or `Insets="SoftInput,Bottom"`
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-input-extensions]] — Auto-focus and keyboard behavior for forms
+- [[uno-toolkit-statusbar-extensions]] — Status bar customization

--- a/plugins/uno-platform-studio/skills/uno-toolkit-segmented-controls/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-segmented-controls/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: uno-toolkit-segmented-controls
+description: "Segmented button groups implemented as a `TabBar` with the segmented style."
+when_to_use: "Use when offering 2–5 mutually exclusive inline options (filter modes, view switchers) — the segmented button pattern."
+metadata:
+  author: uno-platform
+  version: "2.6"
+  category: toolkit
+---
+
+# Uno Toolkit Segmented Controls — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Segmented Control Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit segmented control TabBar button group exclusive")
+```
+
+Primary documentation pages:
+- **TabBar & TabBarItem** (segmented section): `external/uno.toolkit.ui/doc/controls/TabBarAndTabBarItem.md`
+
+Fetch the TabBar page and look for segmented control styles:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/TabBarAndTabBarItem.md")
+```
+
+## Critical Rules
+
+- The segmented style key is **`SegmentedStyle`** — apply it on the `TabBar` (`Style="{StaticResource SegmentedStyle}"`). There is no `SegmentedTabBarStyle` key; using that name will silently fall through to the default `TabBar` look.
+
+## Key Principles (Stable)
+
+- Segmented controls use `TabBar` with `Style="{StaticResource SegmentedStyle}"`
+- Each option is a `TabBarItem`
+- Single selection mode — mutually exclusive options
+- The concrete segmented-button visual comes from the active design-theme
+
+## Related Skills
+
+- [[uno-toolkit-tabbar]] — Full TabBar reference
+- [[uno-toolkit-chip]] — Alternative selection via ChipGroup

--- a/plugins/uno-platform-studio/skills/uno-toolkit-selector-extensions/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-selector-extensions/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: uno-toolkit-selector-extensions
+description: "Use SelectorExtensions to sync a Selector control (FlipView, ListView) with a PipsPager. The PipsPager attached property auto-syncs NumberOfPages and SelectedIndex."
+when_to_use: "Use when synchronising a `PipsPager` indicator with a `FlipView` or `ListView` selection — carousel and slideshow UIs. The attached property auto-syncs `NumberOfPages` and `SelectedIndex` between the two controls."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit Selector Extensions — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the SelectorExtensions Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit SelectorExtensions PipsPager Selector sync FlipView")
+```
+
+Primary documentation page:
+- **Selector Extensions**: `external/uno.toolkit.ui/doc/helpers/Selector-extensions.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/helpers/Selector-extensions.md")
+```
+
+## Key Principles (Stable)
+
+- Only one attached property: `utu:SelectorExtensions.PipsPager`
+- The property must be set on the **Selector control** (FlipView, ListView), **NOT** on the PipsPager
+- Automatically syncs `NumberOfPages` and `SelectedIndex` bidirectionally
+- Swiping the Selector updates the pip; clicking a pip navigates the Selector
+- Do not manually set `NumberOfPages` on the PipsPager — it is auto-managed
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-flipview-extensions]] — Previous/Next buttons for FlipView
+- [[uno-toolkit-itemsrepeater-extensions]] — Selection for ItemsRepeater

--- a/plugins/uno-platform-studio/skills/uno-toolkit-shadowcontainer/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-shadowcontainer/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: uno-toolkit-shadowcontainer
+description: "Use ShadowContainer to add multiple layered shadows to controls. Supports both drop shadows and inner (inset) shadows."
+when_to_use: "Use when `ThemeShadow` is insufficient — multiple stacked shadows, inset shadows, or precise per-shadow colors. Each shadow exposes offset, blur, spread, color, and opacity."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit ShadowContainer — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the ShadowContainer Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit ShadowContainer shadow drop inner inset layer")
+```
+
+Primary documentation page:
+- **ShadowContainer**: `external/uno.toolkit.ui/doc/controls/ShadowContainer.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/ShadowContainer.md")
+```
+
+### Step 2: For How-To / Walkthrough
+
+```
+uno_platform_docs_search("ShadowContainer howto walkthrough shadow example")
+```
+
+## Key Principles (Stable)
+
+- Shadow properties work like CSS `box-shadow` — the API is a 1-to-1 mapping
+- `ShadowCollection` property contains a collection of `Shadow` items
+- Each `Shadow` has: `OffsetX`, `OffsetY`, `BlurRadius`, `SpreadRadius`, `Color`, `Opacity`
+- `IsInner="True"` creates an inset shadow
+- **Background must be set on ShadowContainer, not on the child** for inner shadows to work
+- Multiple shadows layer on top of each other for complex effects
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-card]] — Cards with built-in elevation
+- [[uno-themes-material]] — Material elevation extension

--- a/plugins/uno-platform-studio/skills/uno-toolkit-statusbar-extensions/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-statusbar-extensions/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: uno-toolkit-statusbar-extensions
+description: "Attached properties (`StatusBar.Foreground`, `StatusBar.Background`) for customising the system status bar from XAML on mobile platforms."
+when_to_use: "Use when customising the system status bar on iOS or Android — light vs dark icons, background tint, or visibility — per page from XAML."
+metadata:
+  author: uno-platform
+  version: "2.5"
+  category: toolkit
+---
+
+# Uno Toolkit StatusBar Extensions — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the StatusBar Extensions Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit StatusBar extensions foreground background color iOS Android")
+```
+
+Primary documentation page:
+- **StatusBar Extensions**: `external/uno.toolkit.ui/doc/helpers/StatusBar-extensions.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/helpers/StatusBar-extensions.md")
+```
+
+## Critical Rules
+
+- **`StatusBar.Foreground` is a `StatusBarForegroundTheme` enum value, NOT a Brush.** Use attribute syntax with a bare enum name: `utu:StatusBar.Foreground="Light"` (or `Dark`, `Auto`, `AutoInverse`). Element syntax or a Brush value (e.g. `<utu:StatusBar.Foreground><SolidColorBrush Color="White"/></utu:StatusBar.Foreground>`) is **invalid**.
+- `StatusBar.Background` *is* a color/brush — accepts an attribute color name or a `{StaticResource}` brush.
+- The class is **`StatusBar`**, not `StatusBarExtensions`, despite the file/skill name.
+
+## Key Principles (Stable)
+
+- `utu:StatusBar.Foreground` — StatusBarForegroundTheme enum value
+- `utu:StatusBar.Background` — color or brush
+- StatusBarForegroundTheme values: `Light` (white icons), `Dark` (black icons), `Auto` (matches theme, updates on change), `AutoInverse` (opposite of theme, updates on change)
+- Applied as attached properties on the Page element
+- Works on iOS and Android only
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-safearea]] — Safe area insets for status bar

--- a/plugins/uno-platform-studio/skills/uno-toolkit-system-theme-helper/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-system-theme-helper/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: uno-toolkit-system-theme-helper
+description: "Use SystemThemeHelper to detect system theme (light/dark), check if dark mode is active, and set application theme. Provides static methods for theme retrieval and management."
+when_to_use: "Use when reading or programmatically switching dark / light mode from C# (not the XAML `ThemeResource` lookup path) — detecting the current system theme, setting the application theme at runtime, or toggling between modes."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit SystemThemeHelper — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the SystemThemeHelper Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit SystemThemeHelper theme light dark mode detect")
+```
+
+Primary documentation page:
+- **SystemThemeHelper**: `external/uno.toolkit.ui/doc/helpers/SystemThemeHelper.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/helpers/SystemThemeHelper.md")
+```
+
+## Key Principles (Stable)
+
+- `SystemThemeHelper.GetCurrentOsTheme()` — returns `ApplicationTheme.Light` or `ApplicationTheme.Dark`
+- `SystemThemeHelper.GetRootTheme(XamlRoot?)` — gets the app theme for a given XamlRoot
+- `SystemThemeHelper.IsRootInDarkMode(XamlRoot?)` — quick check if dark mode is active
+- `SystemThemeHelper.SetRootTheme(XamlRoot?, bool)` — set theme (`true` = dark)
+- `SystemThemeHelper.SetApplicationTheme(XamlRoot?, ElementTheme)` — set theme using ElementTheme enum
+- **No `ThemeChanged` event exists** — there is no event to subscribe to for theme changes
+- Namespace: `using Uno.Toolkit.UI;`
+
+## Related Skills
+
+- [[uno-themes-semantic-colors-brushes]] — Semantic color palette and brush system

--- a/plugins/uno-platform-studio/skills/uno-toolkit-tabbar/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-tabbar/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: uno-toolkit-tabbar
+description: "Use TabBar and TabBarItem for tab navigation with icons, labels, badges, and selection indicators. Supports bottom navigation, top tabs, and vertical tabs."
+when_to_use: "Use when styling a `TabBar`'s visual appearance (icons, labels, badges, selection indicator, bottom / top / vertical orientation). For region wiring inside a navigation shell, use `uno-navigation-tabbar` instead. Always set an explicit `Style` for proper appearance."
+metadata:
+  author: uno-platform
+  version: "2.5"
+  category: toolkit
+---
+
+# Uno Toolkit TabBar — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the TabBar Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit TabBar TabBarItem bottom navigation styles icons badges")
+```
+
+Primary documentation page:
+- **TabBar & TabBarItem**: `external/uno.toolkit.ui/doc/controls/TabBarAndTabBarItem.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/TabBarAndTabBarItem.md")
+```
+
+### Step 2: For TabBar with Navigation Extensions
+
+If using TabBar as a navigation control:
+
+See the `uno-navigation-tabbar` skill for region-based navigation integration.
+
+### Step 3: For Chefs TabBar Example
+
+```
+uno_platform_docs_search("Chefs TabBar navigate bottom tab example")
+```
+
+Key page:
+- **Chefs Navigate TabBar**: `external/uno.chefs/doc/toolkit/NavigateTabBar.md`
+
+## Key Principles (Stable)
+
+- **Always apply a style** to TabBar for proper appearance (e.g., `BottomTabBarStyle`, `TopTabBarStyle`, `VerticalTabBarStyle`)
+- Styling goes on the **TabBar container**, not individual TabBarItems
+- `TabBarItem` supports `Icon`, `Content` (label), and `Badge`
+- For navigation, use with `uen:Region.Name` on each TabBarItem
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-navigation-tabbar]] — TabBar with Navigation Extensions
+- [[uno-toolkit-tabbaritem-extensions]] — TabBarItem attached properties
+- [[uno-toolkit-segmented-controls]] — Segmented control style

--- a/plugins/uno-platform-studio/skills/uno-toolkit-tabbaritem-extensions/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-tabbaritem-extensions/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: uno-toolkit-tabbaritem-extensions
+description: "Use TabBarItemExtensions to configure TabBarItem on-click navigation behavior."
+when_to_use: "Use when a `TabBarItem` must trigger navigation directly on click — the attached properties wire the tap into a navigation request without a code-behind handler."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit TabBarItem Extensions — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the TabBarItem Extensions Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit TabBarItem extensions command badge selection indicator")
+```
+
+Primary documentation page:
+- **TabBarItem Extensions**: `external/uno.toolkit.ui/doc/helpers/TabBarItem-extensions.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/helpers/TabBarItem-extensions.md")
+```
+
+## Key Principles (Stable)
+
+- Attached properties for `TabBarItem` controls
+- Enables on-click navigation behavior
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-tabbar]] — TabBar control reference
+- [[uno-toolkit-command-extensions]] — General command extensions

--- a/plugins/uno-platform-studio/skills/uno-toolkit-visualstatemanager-extensions/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-visualstatemanager-extensions/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: uno-toolkit-visualstatemanager-extensions
+description: "Use VisualStateManagerExtensions to create data-driven visual states. Bind VisualState directly to view model properties."
+when_to_use: "Use when visual states must be driven by view-model properties rather than `VisualStateManager.GoToState` calls from code-behind — bind the active state name (e.g. an enum) and the framework swaps states automatically."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit VisualStateManager Extensions — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the VisualStateManager Extensions Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit VisualStateManager extensions data driven visual state binding")
+```
+
+Primary documentation page:
+- **VisualStateManager Extensions**: `external/uno.toolkit.ui/doc/helpers/VisualStateManager-extensions.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/helpers/VisualStateManager-extensions.md")
+```
+
+## Key Principles (Stable)
+
+- `utu:VisualStateManagerExtensions.States` — attached property bound to a string property (note: **States** plural)
+- Supports comma, semicolon, or space separated list for multiple concurrent states from different VisualStateGroups
+- When the bound property changes, the matching VisualState is activated
+- Property value maps directly to VisualState name
+- Eliminates need for code-behind `VisualStateManager.GoToState()` calls
+- **Important**: `VisualStateManager.VisualStateGroups` must be defined on the same element that has the `States` attached property
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-responsive]] — Responsive layout based on screen size

--- a/plugins/uno-platform-studio/skills/uno-toolkit-zoomcontentcontrol/SKILL.md
+++ b/plugins/uno-platform-studio/skills/uno-toolkit-zoomcontentcontrol/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: uno-toolkit-zoomcontentcontrol
+description: "Zoomable and pannable container for images, maps, diagrams, or document viewers."
+when_to_use: "Use when zoom and pan are needed for images, maps, diagrams, or document viewers — mouse wheel zoom, middle-click pan, pinch-to-zoom, configurable min/max zoom levels, and programmatic control."
+metadata:
+  author: uno-platform
+  version: "2.5"
+  category: toolkit
+---
+
+# Uno Toolkit ZoomContentControl — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the ZoomContentControl Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit ZoomContentControl zoom pan pinch mouse wheel")
+```
+
+Primary documentation page:
+- **ZoomContentControl**: `external/uno.toolkit.ui/doc/controls/ZoomContentControl.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/ZoomContentControl.md")
+```
+
+## Critical Rules
+
+- The fit-to-available-size property is **`AutoFit`** (boolean). There is **no `AutoFitToCanvas`** property — that name does not exist on `ZoomContentControl`.
+- Programmatic zoom uses methods `ZoomTo(float)` and `ZoomToRect(Rect)` on the control instance — not a settable `Zoom` property.
+
+## Key Principles (Stable)
+
+- `MinZoomLevel` and `MaxZoomLevel` — zoom range
+- `ZoomLevel` — current zoom (bindable, two-way)
+- `IsZoomAllowed` — enable/disable zoom
+- `IsPanAllowed` — enable/disable pan
+- `AutoFit` — fit content to available size
+- Supports mouse wheel, middle-click pan, pinch-to-zoom gestures
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- (standalone control, no primary dependencies)

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,47 @@
+# Uno Platform Agent Skills
+
+Standalone copies of the Uno Platform skills for AI coding agents, covering MVUX, navigation, Uno Toolkit, theming (Material, Simple, semantic colors), and UI testing.
+
+This folder is for agents that **don't use the plugin system**: Cursor, Gemini CLI, Windsurf, Cline, and others. If your agent supports plugins (Claude Code, GitHub Copilot CLI, Copilot in VS Code, OpenAI Codex CLI), prefer installing the [`uno-platform-studio` plugin](../plugins/uno-platform-studio) instead, which bundles these same skills with proper metadata.
+
+## Install all skills
+
+Each skill is a self-contained folder with a `SKILL.md` (and optional `references/`). All skills are named `uno-<category>-<topic>`, so a `uno-*` glob copies the full catalog.
+
+Cursor example:
+
+```bash
+git clone https://github.com/unoplatform/studio.git
+mkdir -p ~/.cursor/skills
+cp -r studio/skills/uno-* ~/.cursor/skills/
+```
+
+```powershell
+git clone https://github.com/unoplatform/studio.git
+New-Item -ItemType Directory -Force "$HOME/.cursor/skills" | Out-Null
+Copy-Item studio/skills/uno-* "$HOME/.cursor/skills/" -Recurse
+```
+
+For other agents, use the same commands with your agent's skills directory as the target.
+
+## Install individual skills
+
+Copy just the folder(s) you need:
+
+```bash
+cp -r studio/skills/uno-mvux-feed-basics ~/.cursor/skills/
+```
+
+Skills can also be installed per project instead of per user. For example, an agent that reads project-level skills from a `skills/` convention folder:
+
+```
+your-project/
+└── <agent-folder>/
+    └── skills/
+        └── uno-mvux-feed-basics/
+            └── SKILL.md
+```
+
+## Maintenance note
+
+This folder is a **mirror** of [`plugins/uno-platform-studio/skills/`](../plugins/uno-platform-studio/skills). The plugin copy is the source of truth: make edits there and sync them here. The two trees must stay identical (except this README).

--- a/skills/uno-mvux-commands/SKILL.md
+++ b/skills/uno-mvux-commands/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: uno-mvux-commands
+description: "Create and use commands in MVUX for user interactions."
+when_to_use: "Use when binding a Button (or other control) to a method on the Model, understanding how methods become commands in the generated ViewModel, passing feed/state values as parameters to commands, controlling which methods generate commands (implicit vs explicit), or disabling command generation for specific methods."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: mvux
+---
+
+# MVUX Commands — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Commands Documentation
+
+Search for and fetch the commands documentation:
+
+```
+uno_platform_docs_search("MVUX commands automatic generation method invocation")
+```
+
+Primary documentation pages:
+- **Commands Reference**: `external/uno.extensions/doc/Learn/Mvux/Advanced/Commands.md`
+- **Commands How-To**: `external/uno.extensions/doc/Learn/Mvux/Walkthrough/Commands.howto.md`
+
+Fetch the reference page for complete details:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Advanced/Commands.md")
+```
+
+### Step 2: Understand Implicit Command Generation
+
+From the fetched docs, any public method on a Model automatically becomes a command in the generated ViewModel. The reference page covers:
+- Basic command generation rules
+- Using `CommandParameter` from XAML
+- Additional feed parameters (method parameter names matching feed property names)
+- The `[ImplicitCommands]` attribute to enable/disable generation
+
+### Step 3: For How-To Walkthroughs
+
+For step-by-step examples:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Walkthrough/Commands.howto.md")
+```
+
+This covers creating basic commands, using feed values in commands, can-execute logic, and disabling command generation.
+
+### Step 4: For Explicit Command Creation
+
+If the user needs manual control over commands, the reference page has an "Explicit command creation" section covering `Command.Create(...)`.
+
+## Critical Rules
+
+- **Feed parameter injection works for any feed type** (`IFeed<T>`, `IListFeed<T>`, `IState<T>`, `IListState<T>`) — the matching parameter receives a *snapshot* of the current value.
+- **But you can only mutate writable types from inside a command body.** `IState<T>` and `IListState<T>` expose `UpdateAsync` / `AddAsync` / `RemoveAsync`. `IFeed<T>` and `IListFeed<T>` are **read-only** — calling `.Update(...)`, `.UpdateAsync(...)`, `.AddAsync(...)`, or `.RemoveAsync(...)` on an injected `IListFeed`/`IFeed` is a compile error.
+- If a command needs to mutate a collection, the property on the Model must be `IListState<T>` (not `IListFeed<T>`); convert with `ListState.FromFeed(this, sourceFeed)` if needed.
+
+## Key Principles (Stable)
+
+- Any public method on a `*Model` partial record generates a command in the ViewModel
+- Commands are automatically `IAsyncCommand` — they handle async properly
+- Feed parameter injection: a method parameter whose name/type matches a Feed property gets the current feed value injected
+- Use `[ImplicitCommands(false)]` on a Model to disable automatic generation
+- Commands are bound in XAML via `Command="{Binding MethodName}"`
+- The method name becomes the command name (e.g., `Save()` → `Save` command)
+
+## Related Skills
+
+- [[uno-mvux-state-basics]] — States that commands often update
+- [[uno-mvux-feed-basics]] — Feeds whose values commands can consume
+- [[uno-mvux-selection]] — Selection-aware commands

--- a/skills/uno-mvux-commands/SKILL.md
+++ b/skills/uno-mvux-commands/SKILL.md
@@ -59,6 +59,7 @@ If the user needs manual control over commands, the reference page has an "Expli
 - **Feed parameter injection works for any feed type** (`IFeed<T>`, `IListFeed<T>`, `IState<T>`, `IListState<T>`) — the matching parameter receives a *snapshot* of the current value.
 - **But you can only mutate writable types from inside a command body.** `IState<T>` and `IListState<T>` expose `UpdateAsync` / `AddAsync` / `RemoveAsync`. `IFeed<T>` and `IListFeed<T>` are **read-only** — calling `.Update(...)`, `.UpdateAsync(...)`, `.AddAsync(...)`, or `.RemoveAsync(...)` on an injected `IListFeed`/`IFeed` is a compile error.
 - If a command needs to mutate a collection, the property on the Model must be `IListState<T>` (not `IListFeed<T>`); convert with `ListState.FromFeed(this, sourceFeed)` if needed.
+- **When mutating via `UpdateAsync`, the updater must be pure** — derive the new value solely from the `current` value, with no captured external state or side effects. See [[uno-mvux-state-basics]] and [[uno-mvux-liststate]] for details.
 
 ## Key Principles (Stable)
 

--- a/skills/uno-mvux-feed-basics/SKILL.md
+++ b/skills/uno-mvux-feed-basics/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: uno-mvux-feed-basics
+description: "Create and use IFeed<T> for async data in MVUX."
+when_to_use: "Use when loading data from a service or API into MVUX, creating reactive data sources that automatically handle loading/error states, transforming async data with operators like `Select` or `Where`, understanding the difference between feeds and states, or refreshing data using `Signal`."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: mvux
+---
+
+# MVUX Feed Basics — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Feed Reference Documentation
+
+Search for and fetch the feed documentation:
+
+```
+uno_platform_docs_search("MVUX Feed IFeed async data creation")
+```
+
+Primary documentation pages:
+- **Feed Reference**: `external/uno.extensions/doc/Reference/Reactive/feed.md`
+- **Simple Feed How-To**: `external/uno.extensions/doc/Learn/Mvux/Walkthrough/SimpleFeed.howto.md`
+
+Fetch the reference page for complete API details:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Reference/Reactive/feed.md")
+```
+
+### Step 2: Learn Feed Creation Methods
+
+From the fetched docs, the key factory methods on the `Feed` static class are:
+- `Feed.Async(...)` — from a `Task<T>` returning method
+- `Feed.AsyncEnumerable(...)` — from an `IAsyncEnumerable<T>`
+- `Feed.Create(...)` — from a custom async function
+
+### Step 3: For Feed Operators (Select, Where)
+
+If the user needs to transform feed data, search for operators:
+
+```
+uno_platform_docs_search("MVUX feed operators Select Where transform")
+```
+
+The feed reference page covers all operators in the "Operators" section.
+
+### Step 4: For Feed Refresh / Signal
+
+If the user needs to trigger a feed refresh:
+
+```
+uno_platform_docs_search("MVUX feed refresh Signal trigger reload")
+```
+
+The feed reference page has a section on `Signal` for manual refresh triggers.
+
+### Step 5: For How-To Walkthroughs
+
+For step-by-step examples of showing feed data on the UI:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Walkthrough/SimpleFeed.howto.md")
+```
+
+This covers binding feed data, showing errors, and using feeds inside DataTemplates.
+
+## Key Principles (Stable)
+
+- `IFeed<T>` is **read-only** — it cannot be updated from the UI
+- Feeds automatically track loading/error/none/value states
+- Feeds are **stateless** — they don't cache values (use `IState<T>` for caching)
+- The service method should accept a `CancellationToken` parameter for proper cancellation
+- Service return types should use `ValueTask<T>` or `Task<T>`
+- For collections, use `IListFeed<T>` instead (see `uno-mvux-listfeed` skill)
+
+## Related Skills
+
+- [[uno-mvux-overview]] — MVUX architecture concepts
+- [[uno-mvux-feedview]] — Displaying feed data with FeedView control
+- [[uno-mvux-state-basics]] — Mutable reactive data (IState<T>)
+- [[uno-mvux-listfeed]] — Reactive collections (IListFeed<T>)

--- a/skills/uno-mvux-feedview/SKILL.md
+++ b/skills/uno-mvux-feedview/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: uno-mvux-feedview
+description: "Display async feed data with FeedView control."
+when_to_use: "Use when displaying data from an `IFeed<T>` or `IState<T>` in XAML, showing loading spinners, error messages, or empty-state UI automatically, customizing templates for different data states (value, progress, error, none), or binding feed data inside a `DataTemplate`."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: mvux
+---
+
+# FeedView Control — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the FeedView Documentation
+
+Search for and fetch the FeedView documentation:
+
+```
+uno_platform_docs_search("MVUX FeedView control displaying async data templates")
+```
+
+Primary documentation pages:
+- **FeedView Reference**: `external/uno.extensions/doc/Learn/Mvux/FeedView.md`
+- **FeedView How-To**: `external/uno.extensions/doc/Learn/Mvux/Walkthrough/FeedView.howto.md`
+
+Fetch the full reference page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/FeedView.md")
+```
+
+### Step 2: Understand FeedView Templates
+
+From the fetched docs, extract the available templates:
+- **ValueTemplate** (default `<DataTemplate>`) — shown when data is available
+- **ProgressTemplate** — shown during loading
+- **ErrorTemplate** — shown when an error occurs
+- **NoneTemplate** — shown when there is no data
+
+### Step 3: For FeedView How-To Walkthroughs
+
+For step-by-step implementation guidance:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Walkthrough/FeedView.howto.md")
+```
+
+This covers rendering `IFeed<T>`, `IState<T>`, customizing templates, and refresh behavior.
+
+### Step 4: For FeedView with Lists
+
+If the user is displaying a collection feed, search for:
+
+```
+uno_platform_docs_search("MVUX FeedView list feed ListView collection display")
+```
+
+Key page:
+- **ListFeed How-To**: `external/uno.extensions/doc/Learn/Mvux/Walkthrough/ListFeed.howto.md`
+
+## Key Principles (Stable)
+
+- XAML namespace: `xmlns:mvux="using:Uno.Extensions.Reactive.UI"`
+- `Source` property binds to the feed/state: `Source="{Binding MyFeed}"`
+- Inside templates, access the data via `{Binding Data}` (e.g., `{Binding Data.Name}`)
+- The default `<DataTemplate>` content child acts as the `ValueTemplate`
+- FeedView automatically provides a `Refresh` command — no need to create one manually
+- FeedView handles all state transitions (loading → value → error) without code-behind
+
+## Related Skills
+
+- [[uno-mvux-feed-basics]] — Creating feeds
+- [[uno-mvux-state-basics]] — Creating mutable states
+- [[uno-mvux-listfeed]] — Reactive collections

--- a/skills/uno-mvux-listfeed/SKILL.md
+++ b/skills/uno-mvux-listfeed/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: uno-mvux-listfeed
+description: "Create and use IListFeed<T> for reactive collections in MVUX."
+when_to_use: "Use when loading a list of items from a service or API, displaying collections in `ListView`, `GridView`, or `ItemsRepeater`, filtering list data reactively, or choosing between `IListFeed<T>` (read-only) and `IListState<T>` (mutable)."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: mvux
+---
+
+# MVUX ListFeed — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the ListFeed Reference Documentation
+
+Search for and fetch the documentation:
+
+```
+uno_platform_docs_search("MVUX ListFeed reactive collection IListFeed")
+```
+
+Primary documentation pages:
+- **ListFeed Reference**: `external/uno.extensions/doc/Reference/Reactive/listfeed.md`
+- **ListFeed How-To**: `external/uno.extensions/doc/Learn/Mvux/Walkthrough/ListFeed.howto.md`
+
+Fetch the full reference:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Reference/Reactive/listfeed.md")
+```
+
+### Step 2: Learn ListFeed Creation Methods
+
+From the fetched docs, the key factory methods on the `ListFeed` static class:
+- `ListFeed.Async(...)` — from a method returning `Task<IImmutableList<T>>`
+- `ListFeed.AsyncEnumerable(...)` — from an `IAsyncEnumerable<IImmutableList<T>>`
+- `ListFeed.PaginatedAsync(...)` — for paginated/infinite scroll (see `uno-mvux-pagination` skill)
+
+### Step 3: For ListFeed Operators
+
+The reference page covers operators like `Where`, `Select`, and `AsFeed`. These operate on individual items in the collection.
+
+### Step 4: For How-To Walkthroughs
+
+For step-by-step examples:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Walkthrough/ListFeed.howto.md")
+```
+
+This covers loading a list, showing it with FeedView, filtering with `Where`, and when to use feeds vs states.
+
+### Step 5: For Displaying Lists in XAML
+
+The how-to page shows how to bind `IListFeed<T>` to `ListView` via `FeedView` and access items through `{Binding Data}`.
+
+## Key Principles (Stable)
+
+- `IListFeed<T>` is **read-only** — use `IListState<T>` for add/remove/update
+- Service methods should return `ValueTask<IImmutableList<T>>` (from `System.Collections.Immutable`)
+- Operators like `Where` and `Select` work on individual items, not the list itself
+- ListFeed automatically handles loading/error/empty states
+- Use `IListFeed<T>` when data is pulled from a service and is read-only
+- Use `IListState<T>` when you need to edit the collection client-side
+
+## Key Equality Requirement (Critical)
+
+**All item types used in `IListFeed<T>` MUST support key equality** via `Uno.Extensions.Equality.IKeyEquatable<T>`. Without key equality, MVUX cannot distinguish between a modified entity and a completely different one, causing full list re-renders instead of granular item updates (flickering, lost scroll position, broken animations).
+
+### Automatic generation (recommended)
+
+For `partial record` types, key equality is **auto-generated** when the record has a property named `Id` or `Key`:
+
+```csharp
+public partial record Person(Guid Id, string Name, int Age);
+// IKeyEquatable<Person> is generated automatically — Id is the key
+```
+
+### Explicit key configuration
+
+Use `[Key]` attribute when the key property has a different name, or for composite keys:
+
+```csharp
+public partial record OrderLine(
+    [property: Key] Guid OrderId,
+    [property: Key] int LineNumber,
+    string Product,
+    decimal Price);
+```
+
+Either `Uno.Extensions.Equality.KeyAttribute` or `System.ComponentModel.DataAnnotations.KeyAttribute` can be used.
+
+### Assembly-level defaults
+
+Configure which property names are auto-detected as keys:
+
+```csharp
+[assembly: ImplicitKeyEquality("Id", "Key", "EntityId")]
+```
+
+### Disabling generation
+
+If auto-generation causes issues on a specific type:
+
+```csharp
+[ImplicitKeys(IsEnabled = false)]
+public partial record MyItem(Guid Id, string Name);
+```
+
+### Rules
+
+- The item type **must** be a `partial record` (or manually implement `IKeyEquatable<T>`)
+- At least one key property is required — without it, every update replaces the entire list in the UI
+- Key properties define **identity** (same entity); non-key properties define **state** (changed data)
+- `KeyEquals` returns `true` when two instances represent the same entity, even if other properties differ
+
+## Related Skills
+
+- [[uno-mvux-feed-basics]] — Single-value feeds
+- [[uno-mvux-liststate]] — Mutable reactive collections
+- [[uno-mvux-selection]] — Selection management with list feeds
+- [[uno-mvux-pagination]] — Infinite scroll / paginated lists
+- [[uno-mvux-feedview]] — Displaying feed data in XAML

--- a/skills/uno-mvux-liststate/SKILL.md
+++ b/skills/uno-mvux-liststate/SKILL.md
@@ -120,6 +120,18 @@ public partial record MyItem(Guid Id, string Name);
 - `KeyEquals` returns `true` when two instances represent the same entity, even if other properties differ
 - `UpdateAsync` uses key equality to find the existing item to replace — without it, the update silently fails or replaces the wrong item
 
+## Updater Purity (Critical)
+
+The function passed to `UpdateAsync` (and to the item-level updaters) **must be pure**: derive the new value *solely* from the `current` value it receives, with no capture of external/mutable variables and no side effects. MVUX is stateless and lockless and applies the updater against the current cached value, so an updater that depends on anything other than its input is not guaranteed to produce a stable result. Project the value you were given onto a new immutable value (use `with` expressions on records); never reach outside the lambda for state.
+
+```csharp
+// Correct: pure projection of the current item
+await Items.UpdateAsync(item => item with { IsDone = true });
+
+// Wrong: result captures external mutable state
+await Items.UpdateAsync(_ => _externalItem);
+```
+
 ## Related Skills
 
 - [[uno-mvux-listfeed]] — Read-only reactive collections

--- a/skills/uno-mvux-liststate/SKILL.md
+++ b/skills/uno-mvux-liststate/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: uno-mvux-liststate
+description: "Create and use IListState<T> for mutable reactive collections in MVUX."
+when_to_use: "Use when adding, removing, or updating items in a collection, managing item selection in a list, two-way binding with collections, synchronizing list changes with services via messaging, or converting a read-only `IListFeed<T>` into a mutable `IListState<T>`."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: mvux
+---
+
+# MVUX ListState — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the ListState Documentation
+
+There is no dedicated ListState reference page — it shares documentation with ListFeed and State. Search for:
+
+```
+uno_platform_docs_search("MVUX ListState mutable collection add remove update selection")
+```
+
+Key documentation pages:
+- **ListFeed Reference** (includes ListState): `external/uno.extensions/doc/Reference/Reactive/listfeed.md`
+- **State Reference** (includes list state creation): `external/uno.extensions/doc/Reference/Reactive/state.md`
+- **Usage in Apps** (ListState patterns): `external/uno.extensions/doc/Reference/Reactive/in-apps.md`
+
+Fetch the in-apps reference for practical patterns:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Reference/Reactive/in-apps.md")
+```
+
+### Step 2: For ListState Creation
+
+- `ListState<T>.Empty(this)` — starts with no items
+- `ListState.Async(this, asyncFunc)` — loads initial data from async source
+- Can add `.Selection(...)` to track selected items
+
+### Step 3: For ListState Mutations
+
+Search for mutation operations:
+
+```
+uno_platform_docs_search("MVUX ListState add remove update items operation")
+```
+
+Key operations: `AddAsync`, `RemoveAllAsync`, `UpdateAsync`, `InsertAsync`.
+
+### Step 4: For Messaging Integration
+
+If the user needs list updates from service CRUD operations:
+
+```
+uno_platform_docs_search("MVUX messaging EntityMessage ListState observe")
+```
+
+See the `uno-mvux-messaging` skill for full details.
+
+## Key Principles (Stable)
+
+- `IListState<T>` is **mutable** — supports add/remove/update
+- Created with `ListState<T>.Empty(this)` or `ListState.Async(this, ...)`
+- Supports two-way binding and selection management
+- Records should implement key equality for proper update detection
+- Use `.Selection(state)` to connect selection tracking
+- For read-only lists, prefer `IListFeed<T>` instead
+
+## Key Equality Requirement (Critical)
+
+**All item types used in `IListState<T>` MUST support key equality** via `Uno.Extensions.Equality.IKeyEquatable<T>`. This is essential for `IListState<T>` because mutation operations (`UpdateAsync`, `RemoveAllAsync`, selection tracking) rely on key equality to identify which item to target. Without it, MVUX cannot match an updated instance to its original, causing broken updates, lost selection state, and full list re-renders.
+
+### Automatic generation (recommended)
+
+For `partial record` types, key equality is **auto-generated** when the record has a property named `Id` or `Key`:
+
+```csharp
+public partial record TodoItem(Guid Id, string Title, bool IsComplete);
+// IKeyEquatable<TodoItem> is generated automatically — Id is the key
+```
+
+### Explicit key configuration
+
+Use `[Key]` attribute when the key property has a different name, or for composite keys:
+
+```csharp
+public partial record OrderLine(
+    [property: Key] Guid OrderId,
+    [property: Key] int LineNumber,
+    string Product,
+    decimal Price);
+```
+
+Either `Uno.Extensions.Equality.KeyAttribute` or `System.ComponentModel.DataAnnotations.KeyAttribute` can be used.
+
+### Assembly-level defaults
+
+Configure which property names are auto-detected as keys:
+
+```csharp
+[assembly: ImplicitKeyEquality("Id", "Key", "EntityId")]
+```
+
+### Disabling generation
+
+If auto-generation causes issues on a specific type:
+
+```csharp
+[ImplicitKeys(IsEnabled = false)]
+public partial record MyItem(Guid Id, string Name);
+```
+
+### Rules
+
+- The item type **must** be a `partial record` (or manually implement `IKeyEquatable<T>`)
+- At least one key property is required — without it, mutations and selection cannot identify items
+- Key properties define **identity** (same entity); non-key properties define **state** (changed data)
+- `KeyEquals` returns `true` when two instances represent the same entity, even if other properties differ
+- `UpdateAsync` uses key equality to find the existing item to replace — without it, the update silently fails or replaces the wrong item
+
+## Related Skills
+
+- [[uno-mvux-listfeed]] — Read-only reactive collections
+- [[uno-mvux-selection]] — Selection management
+- [[uno-mvux-messaging]] — Syncing list state with entity changes
+- [[uno-mvux-records]] — Immutable record design with key equality

--- a/skills/uno-mvux-messaging/SKILL.md
+++ b/skills/uno-mvux-messaging/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: uno-mvux-messaging
+description: "Use messaging to sync MVUX states with entity changes."
+when_to_use: "Use when CRUD operations that should update all views showing the same data, decoupling services from models — services broadcast changes, models react, keeping multiple views/pages in sync when shared entities change, or using `EntityMessage<T>` with CommunityToolkit.Mvvm messenger."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: mvux
+---
+
+# MVUX Messaging — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Messaging Documentation
+
+Search for and fetch the messaging documentation:
+
+```
+uno_platform_docs_search("MVUX messaging EntityMessage synchronization CRUD")
+```
+
+Primary documentation pages:
+- **Messaging Reference**: `external/uno.extensions/doc/Learn/Mvux/Advanced/Messaging.md`
+- **Messaging How-To**: `external/uno.extensions/doc/Learn/Mvux/Walkthrough/Messaging.howto.md`
+
+Fetch the reference page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Advanced/Messaging.md")
+```
+
+### Step 2: For How-To Walkthroughs
+
+For step-by-step implementation:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Walkthrough/Messaging.howto.md")
+```
+
+This covers when to use messaging, sending entity messages from services, observing changes in models, and manual message handling.
+
+### Step 3: Understand the Architecture
+
+From the fetched docs, the messaging pattern involves:
+1. **Service** sends `EntityMessage<T>` via `IMessenger.Send(...)`
+2. **Model** uses `.Observe(messenger)` on a `ListState` to auto-apply changes
+3. **Entity changes** (Created/Updated/Deleted) are applied to the matching state
+
+### Step 4: For Manual Message Handling
+
+If the user needs custom logic when messages arrive, the reference page covers the `Update` extension methods that allow manual application of `EntityMessage<T>` to states.
+
+## Key Principles (Stable)
+
+- Register `IMessenger` as a singleton in DI: `services.AddSingleton<IMessenger, WeakReferenceMessenger>()`
+- `EntityMessage<T>` carries an entity change type (Created, Updated, Deleted) and the entity
+- `.Observe(messenger)` on a `ListState` auto-applies incoming entity changes
+- Records need key equality for matching (see `uno-mvux-records` skill)
+- Namespace: `Uno.Extensions.Reactive.Messaging`
+
+## Related Skills
+
+- [[uno-mvux-liststate]] — Mutable collections that messaging updates
+- [[uno-mvux-records]] — Key equality for entity matching
+- [[uno-mvux-commands]] — Commands that trigger CRUD operations

--- a/skills/uno-mvux-overview/SKILL.md
+++ b/skills/uno-mvux-overview/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: uno-mvux-overview
+description: "Understand MVUX (Model-View-Update-eXtended) architecture in Uno Platform."
+when_to_use: "Use when learning the MVUX architecture, comparing MVUX to MVVM or other patterns, setting up a new Uno Platform project with MVUX, or understanding immutable data flow with feeds and states."
+metadata:
+  author: uno-platform
+  version: "2.5"
+  category: mvux
+---
+
+# MVUX Overview — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the MVUX Overview Documentation
+
+Search for and fetch the core MVUX overview page:
+
+```
+uno_platform_docs_search("MVUX overview Model View Update eXtended architecture")
+```
+
+The primary documentation page is:
+- **MVUX Overview**: `external/uno.extensions/doc/Learn/Mvux/Overview.md`
+
+Fetch the full page for comprehensive details:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Overview.md")
+```
+
+### Step 2: Understand Key Concepts
+
+From the fetched documentation, extract and explain:
+
+1. **What MVUX is**: Model-View-Update-eXtended — an MVU variant that supports XAML data binding
+2. **How it differs from MVVM**: Unidirectional data flow, immutable records, automatic state management
+3. **Core types**: `IFeed<T>`, `IState<T>`, `IListFeed<T>`, `IListState<T>`
+4. **Code generation**: Models with `*Model` suffix generate corresponding `*ViewModel` classes
+5. **FeedView control**: The UI control that handles loading/error/value states automatically
+
+### Step 3: For Project Setup Details
+
+If the user needs to set up MVUX in a project, search for setup instructions:
+
+```
+uno_platform_docs_search("MVUX project setup UnoFeatures add MVUX existing app")
+```
+
+Key doc page for setup:
+- **How to set up an MVUX project**: `external/uno.extensions/doc/Learn/Mvux/Tutorials/HowTo-MvuxProject.md`
+
+### Step 4: For MVUX vs MVVM Comparison
+
+If the user wants a comparison, the overview page contains a detailed MVVM vs MVUX data flow section. Fetch:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Overview.md")
+```
+
+Focus on the sections: "What is MVUX?", "eXtended", "MVVM vs MVUX Data Flow", and "Weather App Example".
+
+## Key Principles (Stable)
+
+- Models MUST be `partial record` types with a `Model` suffix (e.g., `MainModel`)
+- All data entities should be C# records (immutable)
+- MVUX requires `<UnoFeatures>MVUX</UnoFeatures>` in the project file
+- The generated ViewModel is what gets set as the `DataContext`, not the Model itself
+- Services are injected via constructor parameters on the record
+
+## Choosing the right MVUX skill
+
+When unsure which MVUX skill applies, pick by intent:
+
+### Getting started
+
+- [[uno-mvux-records]] — Design immutable data models
+- [[uno-mvux-feed-basics]] — Load async data
+
+### Displaying data
+
+- [[uno-mvux-feedview]] — `FeedView` control for all states
+- [[uno-mvux-listfeed]] — Display collections
+
+### User input
+
+- [[uno-mvux-state-basics]] — Two-way binding with states
+- [[uno-mvux-commands]] — Button actions and commands
+
+### Advanced features
+
+- [[uno-mvux-liststate]] — Mutable collections
+- [[uno-mvux-selection]] — Selection management
+- [[uno-mvux-pagination]] — Infinite scroll
+- [[uno-mvux-messaging]] — Entity synchronization

--- a/skills/uno-mvux-pagination/SKILL.md
+++ b/skills/uno-mvux-pagination/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: uno-mvux-pagination
+description: "Implement paginated and infinite scrolling lists in MVUX."
+when_to_use: "Use when loading large datasets incrementally (page by page), implementing infinite scroll in `ListView`, `GridView`, or `ItemsRepeater`, working with APIs that use offset/limit or cursor-based pagination, or using `ListFeed.PaginatedAsync(...)`."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: mvux
+---
+
+# MVUX Pagination — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Pagination Documentation
+
+Search for and fetch the pagination documentation:
+
+```
+uno_platform_docs_search("MVUX pagination infinite scrolling PaginatedAsync")
+```
+
+Primary documentation pages:
+- **Pagination Reference**: `external/uno.extensions/doc/Learn/Mvux/Advanced/Pagination.md`
+- **Pagination in Chefs App**: `external/uno.chefs/doc/mvux/Pagination.md`
+- **Usage in Apps (Pagination section)**: `external/uno.extensions/doc/Reference/Reactive/in-apps.md`
+
+Fetch the reference page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Advanced/Pagination.md")
+```
+
+### Step 2: For Practical Examples
+
+Fetch the Chefs app example for a real-world implementation:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.chefs/doc/mvux/Pagination.md")
+```
+
+### Step 3: Understand Pagination Types
+
+From the fetched docs:
+- **Index-based**: Uses page size and start index (`PageRequest.DesiredSize`, `PageRequest.CurrentCount`)
+- **Cursor/keyset-based**: Uses a cursor token for the next page
+
+### Step 4: For ItemsRepeater Integration
+
+If the user is using `ItemsRepeater` for incremental loading:
+
+```
+uno_platform_docs_search("ItemsRepeater MVUX pagination incremental loading")
+```
+
+Key page:
+- **ItemsRepeater Extensions**: `external/uno.toolkit.ui/doc/helpers/walkthroughs/itemsrepeater-extensions.howto.md`
+
+## Key Principles (Stable)
+
+- Use `ListFeed.PaginatedAsync(...)` to create a paginated list feed
+- The callback receives a `PageRequest` with `DesiredSize` and `CurrentCount`
+- `ListView` supports incremental loading automatically when bound to a paginated feed
+- For `ItemsRepeater`, use the Toolkit's `ItemsRepeaterExtensions` for incremental loading support
+- Pagination works with both index-based and cursor-based APIs
+
+## Related Skills
+
+- [[uno-mvux-listfeed]] — Non-paginated list feeds
+- [[uno-mvux-selection]] — Selection with paginated lists
+- [[uno-toolkit-itemsrepeater-extensions]] — ItemsRepeater incremental loading

--- a/skills/uno-mvux-records/SKILL.md
+++ b/skills/uno-mvux-records/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: uno-mvux-records
+description: "Use immutable records effectively with MVUX."
+when_to_use: "Use when designing data models/entities for MVUX, understanding why MVUX requires records (immutability), implementing key equality for proper item matching in lists, using `with` expressions to create modified copies, or understanding `partial record` requirements for Model classes."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: mvux
+---
+
+# Working with Records in MVUX — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the MVUX Overview (Records Section)
+
+The MVUX overview covers why records are essential:
+
+```
+uno_platform_docs_search("MVUX immutable records data model code generation")
+```
+
+Primary documentation page:
+- **MVUX Overview**: `external/uno.extensions/doc/Learn/Mvux/Overview.md`
+
+Fetch and look for the "Model" and "Creating your own" sections:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Overview.md")
+```
+
+### Step 2: For Key Equality in Messaging/Selection
+
+If the user needs key equality for entity matching (messaging, selection), search for:
+
+```
+uno_platform_docs_search("MVUX key equality entity matching record identifier")
+```
+
+The messaging reference covers how records are matched by key:
+- **Messaging Reference**: `external/uno.extensions/doc/Learn/Mvux/Advanced/Messaging.md`
+
+### Step 3: For General C# Records
+
+If the user needs help with C# record syntax itself, this is standard C# language knowledge — records provide immutability, value equality, `with` expressions, and deconstruction.
+
+## Key Equality Requirement (Critical)
+
+**Record types used as items in MVUX collections (`IListFeed<T>`, `IListState<T>`) MUST support key equality via `Uno.Extensions.Equality.IKeyEquatable<T>`.** Without it, MVUX cannot distinguish a modified entity from a different one — every change forces a full list re-render (flickering, lost scroll position, broken animations). For single-value `IState<T>` / `IFeed<T>`, key equality matters for messaging-driven entity matching.
+
+### Automatic generation (recommended)
+
+For `partial record` types, `IKeyEquatable<T>` is **auto-generated** when the record has a property named `Id` or `Key`:
+
+```csharp
+public partial record Person(Guid Id, string Name, int Age);
+// IKeyEquatable<Person> is generated automatically — Id is the key
+```
+
+### Explicit key configuration
+
+Use `[Key]` (from `Uno.Extensions.Equality` or `System.ComponentModel.DataAnnotations`) when the key property has a different name, or for composite keys:
+
+```csharp
+public partial record OrderLine(
+    [property: Key] Guid OrderId,
+    [property: Key] int LineNumber,
+    string Product,
+    decimal Price);
+```
+
+### Assembly-level defaults
+
+Configure which property names are auto-detected as keys:
+
+```csharp
+[assembly: ImplicitKeyEquality("Id", "Key", "EntityId")]
+```
+
+### Disabling generation
+
+If auto-generation causes issues on a specific type:
+
+```csharp
+[ImplicitKeys(IsEnabled = false)]
+public partial record MyItem(Guid Id, string Name);
+```
+
+### Do not invent the interface name
+
+The interface is exactly **`Uno.Extensions.Equality.IKeyEquatable<T>`**. Do not introduce a generic `IHasKey<T>` or similar invented name — the framework will not recognise it.
+
+### Rules
+
+- The item type **must** be a `partial record` (or manually implement `IKeyEquatable<T>`)
+- At least one key property is required — without it, every update replaces the entire list in the UI
+- Key properties define **identity** (same entity); non-key properties define **state** (changed data)
+- `KeyEquals` returns `true` when two instances represent the same entity, even if other properties differ
+
+## Key Principles (Stable)
+
+- **Data entities** should be `record` types (immutable, value equality)
+- **Model classes** must be `partial record` with a `Model` suffix for code generation
+- Records use `with` expressions to create modified copies: `entity with { Name = "New" }`
+- Value equality means two records with the same data are considered equal
+- Positional records: `public record Person(string Name, int Age);` — concise syntax
+- Models inject services via constructor: `public partial record MainModel(IMyService Service)`
+
+## Related Skills
+
+- [[uno-mvux-overview]] — MVUX architecture requiring records
+- [[uno-mvux-messaging]] — Entity matching depends on key equality
+- [[uno-mvux-selection]] — Selection tracking relies on equality

--- a/skills/uno-mvux-selection/SKILL.md
+++ b/skills/uno-mvux-selection/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: uno-mvux-selection
+description: "Implement item selection in MVUX lists."
+when_to_use: "Use when tracking the selected item(s) in a `ListView`, `GridView`, or other selector, implementing single-item selection with `IState<T>`, implementing multi-item selection with `IState<IImmutableList<T>>`, reacting to selection changes in the Model, or manual (programmatic) selection of items."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: mvux
+---
+
+# MVUX Selection — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Selection Documentation
+
+Search for and fetch the selection documentation:
+
+```
+uno_platform_docs_search("MVUX selection Selection method IListFeed IListState")
+```
+
+Primary documentation pages:
+- **Selection Reference**: `external/uno.extensions/doc/Learn/Mvux/Advanced/Selection.md`
+- **Selection How-To**: `external/uno.extensions/doc/Learn/Mvux/Walkthrough/Selection.howto.md`
+- **Selection in Chefs App**: `external/uno.chefs/doc/mvux/Selection.md`
+
+Fetch the reference page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Advanced/Selection.md")
+```
+
+### Step 2: For How-To Walkthroughs
+
+For step-by-step examples:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Mvux/Walkthrough/Selection.howto.md")
+```
+
+This covers single selection, multi selection, checking selection from commands, and programmatic selection.
+
+### Step 3: Understand Selection Patterns
+
+From the fetched docs:
+- **Single selection**: `.Selection(selectedState)` where `selectedState` is `IState<T?>`
+- **Multi-selection**: `.Selection(selectedStates)` where `selectedStates` is `IState<IImmutableList<T>>`
+- **Manual selection**: Use `IListState<T>` instead of `IListFeed<T>` for programmatic item selection
+
+### Step 4: For Selection with Commands
+
+If the user needs to use the selected item in a command (e.g., "Edit" button):
+
+```
+uno_platform_docs_search("MVUX selection command check current selected item button")
+```
+
+## Key Principles (Stable)
+
+- Use `.Selection(state)` operator on `IListFeed<T>` or `IListState<T>` to enable selection tracking
+- Single selection: `IState<T?>` holds the selected item
+- Multi-selection: `IState<IImmutableList<T>>` holds selected items
+- The `ListView` SelectionMode must be set appropriately (Single, Multiple, Extended)
+- Selection sync happens automatically between the UI control and the state
+- For programmatic/manual selection, use `IListState<T>` (not `IListFeed<T>`)
+
+## Related Skills
+
+- [[uno-mvux-listfeed]] — Read-only collections with selection
+- [[uno-mvux-liststate]] — Mutable collections with selection
+- [[uno-mvux-commands]] — Commands that use selected items

--- a/skills/uno-mvux-state-basics/SKILL.md
+++ b/skills/uno-mvux-state-basics/SKILL.md
@@ -62,6 +62,16 @@ See also the `uno-mvux-commands` skill.
 - **The mutation method is `UpdateAsync`** — `public static ValueTask UpdateAsync<T>(this IState<T> state, Func<T?, T?> updater, CancellationToken ct = default)`.
 - **There is no `Update` method on `IState<T>`** — calling `state.Update(x => ...)` is a compile error. The baseline model frequently emits this wrong name; the skill must keep the correct name front-and-centre.
 - `UpdateAsync` returns `ValueTask` — `await` it from inside an `async` method (typically a command body).
+- **The updater must be pure** — derive the new value *solely* from the `current` parameter it receives. Do not capture or read external/mutable variables, and do not perform side effects inside it. MVUX is stateless and lockless: the updater is applied against the state's current cached value, so a function that depends on anything other than `current` is not guaranteed to produce a stable result. The official docs model this by declaring the updater as a `static` local function, which the compiler prevents from capturing enclosing state:
+
+  ```csharp
+  // Correct: a pure projection of the value you were given
+  static int increment(int current) => current + 1;
+  await Counter.UpdateAsync(increment);
+
+  // Wrong: result is not derived from `current`, it captures external state
+  await Counter.UpdateAsync(_ => _someExternalField);
+  ```
 
 ## Key Principles (Stable)
 

--- a/skills/uno-mvux-state-basics/SKILL.md
+++ b/skills/uno-mvux-state-basics/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: uno-mvux-state-basics
+description: "Create and use IState<T> for mutable reactive data in MVUX."
+when_to_use: "Use when implementing two-way data binding (e.g., TextBox, Slider, ToggleSwitch), accepting and storing user input, maintaining editable application state, programmatically updating a value from a command or service call, or understanding the difference between `IFeed<T>` (read-only) and `IState<T>` (read/write)."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: mvux
+---
+
+# MVUX State Basics — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the State Reference Documentation
+
+Search for and fetch the state documentation:
+
+```
+uno_platform_docs_search("MVUX State IState mutable two-way binding")
+```
+
+Primary documentation page:
+- **State Reference**: `external/uno.extensions/doc/Reference/Reactive/state.md`
+
+Fetch the full reference:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Reference/Reactive/state.md")
+```
+
+### Step 2: Learn State Creation Methods
+
+From the fetched docs, the key factory methods on the `State` and `State<T>` classes:
+- `State<T>.Empty(this)` — starts with no value
+- `State<T>.Value(this, initialValue)` — starts with a sync value
+- `State.Async(this, asyncFunc)` — initial value from async source
+- `State.FromFeed(this, feed)` — wraps a feed as mutable state
+
+### Step 3: For Updating State Programmatically
+
+The state reference page covers `UpdateAsync`, `SetAsync`, and `ForEach` for subscribing to changes. Focus on the "Update: How to update a state" section.
+
+### Step 4: For Two-Way Binding Examples
+
+The state reference page includes a "Binding the View to a State" section showing how XAML two-way binding works automatically with generated ViewModels.
+
+### Step 5: For Commands with State
+
+If the user needs commands that interact with states:
+
+```
+uno_platform_docs_search("MVUX commands state update async method")
+```
+
+See also the `uno-mvux-commands` skill.
+
+## Critical Rules
+
+- **The mutation method is `UpdateAsync`** — `public static ValueTask UpdateAsync<T>(this IState<T> state, Func<T?, T?> updater, CancellationToken ct = default)`.
+- **There is no `Update` method on `IState<T>`** — calling `state.Update(x => ...)` is a compile error. The baseline model frequently emits this wrong name; the skill must keep the correct name front-and-centre.
+- `UpdateAsync` returns `ValueTask` — `await` it from inside an `async` method (typically a command body).
+
+## Key Principles (Stable)
+
+- `IState<T>` is **mutable** — it supports read and write operations
+- States **cache** their current value (unlike feeds which are stateless)
+- The generated ViewModel exposes states as two-way bindable properties automatically
+- `State<T>.Empty(this)` requires passing `this` as the owner for lifecycle management
+- Use `await state.UpdateAsync(current => newValue)` to update programmatically
+- Use `state.ForEach(async (value, ct) => { ... })` to react to changes
+
+## Related Skills
+
+- [[uno-mvux-feed-basics]] — Read-only reactive data (IFeed<T>)
+- [[uno-mvux-commands]] — Command generation and interaction with states
+- [[uno-mvux-liststate]] — Mutable reactive collections (IListState<T>)
+- [[uno-mvux-feedview]] — Displaying state data with FeedView

--- a/skills/uno-navigation-code/SKILL.md
+++ b/skills/uno-navigation-code/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: uno-navigation-code
+description: "Programmatic navigation via `INavigator` extension methods (`NavigateRouteAsync`, `NavigateViewModelAsync`, `NavigateBackAsync`, and the `*ForResultAsync` overloads)."
+when_to_use: "Use when navigating from a ViewModel, code-behind, or a service, including back-navigation (`NavigateBackAsync`), result-returning navigation (`NavigateViewModelForResultAsync<TViewModel, TResult>`, `NavigateBackWithResultAsync`), or choosing the right `Navigate*Async` overload for the scenario."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: navigation
+---
+
+# Uno Navigation from Code — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Code Navigation Documentation
+
+```
+uno_platform_docs_search("Uno Navigation code programmatic NavigateRouteAsync NavigateViewModelAsync")
+```
+
+Primary documentation pages:
+- **Navigation via Code Behind (Chefs)**: `external/uno.chefs/doc/navigation/NavigationCodeBehind.md`
+- **Navigation Overview (Code section)**: `external/uno.extensions/doc/Learn/Navigation/NavigationOverview.md`
+
+Fetch the Chefs code-behind page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.chefs/doc/navigation/NavigationCodeBehind.md")
+```
+
+### Step 2: For Specific Navigation Methods
+
+The documentation covers two parallel families:
+
+**Non-result overloads** — navigate to a destination, don't expect a return value:
+- `NavigateRouteAsync("routeName")` — navigate by route string
+- `NavigateViewAsync<TView>()` — navigate to a specific view type
+- `NavigateViewModelAsync<TViewModel>()` — navigate to the route registered for a ViewModel type
+- `NavigateDataAsync<TData>(data)` — navigate with data; the destination is resolved from the data type
+- `NavigateBackAsync()` — pop one level off the back stack
+
+**Result overloads** — navigate AND retrieve a typed result from the destination page:
+- `NavigateRouteForResultAsync<TResult>("routeName")`
+- `NavigateViewForResultAsync<TView, TResult>()`
+- `NavigateViewModelForResultAsync<TViewModel, TResult>()`
+- `NavigateDataForResultAsync<TData, TResult>()`
+- `NavigateBackWithResultAsync(data)` — used on the destination page to return data to the caller
+
+The result overloads return `Task<NavigationResult<TResult>>`. The caller awaits, then reads `.Result` for the returned value.
+
+### Step 3: For Advanced Navigation Techniques
+
+```
+uno_platform_docs_search("Uno Navigation advanced back stack clear navigate techniques")
+```
+
+Key page:
+- **Advanced Page Navigation**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/AdvancedPageNavigation.md`
+
+## Critical Rules
+
+- **Pick the correct overload for the navigation scenario.** Non-result overloads (`NavigateViewModelAsync<TViewModel>`) are for one-way navigation. Result overloads (`NavigateViewModelForResultAsync<TViewModel, TResult>`) are for request-and-await-response flows where the destination page calls `NavigateBackWithResultAsync(data)` to return a value. Using the non-result overload when a return value is needed silently throws away the result.
+- Navigation methods are **extension methods on `INavigator`** — they are not extension methods on `string`, `Route`, or any view type. Get an `INavigator` instance first (constructor injection or `this.GetNavigator()`), then call `await navigator.Navigate*Async(...)`.
+
+## Key Principles (Stable)
+
+- Get `INavigator` via constructor injection or `this.GetNavigator()` extension method
+- All navigation methods are async; non-result overloads return `Task<NavigationResponse>`, result overloads return `Task<NavigationResultResponse<TResult>>`
+- `NavigateViewModelAsync` is the most common one-way overload — maps to the route registered for that ViewModel
+- `NavigateBackAsync()` goes back one level
+- Combine with `Qualifiers.ClearBackStack` to clear navigation history
+- Always `await` navigation calls
+
+## Common Pitfall Example
+
+The second Critical Rule above (extension methods on `INavigator`) is the most-seen mistake. Concrete example:
+
+```csharp
+// WRONG: CS1929 — string has no NavigateRouteAsync
+await "/details".NavigateRouteAsync(...);
+
+// CORRECT: Get INavigator first
+var navigator = this.GetNavigator();
+await navigator.NavigateRouteAsync(this, route: "/details");
+```
+
+In XAML, prefer the `uen:Navigation.Request` attached property instead of code-behind navigation:
+
+```xml
+<Button Content="Go to Details"
+        uen:Navigation.Request="Details"/>
+```
+
+## Related Skills
+
+- [[uno-navigation-routes]] — Route registration (required for code navigation)
+- [[uno-navigation-data]] — Passing data during navigation
+- [[uno-navigation-qualifiers]] — Navigation qualifiers (clear back stack, etc.)
+- [[uno-navigation-xaml]] — Declarative alternative to code navigation

--- a/skills/uno-navigation-contentcontrol/SKILL.md
+++ b/skills/uno-navigation-contentcontrol/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: uno-navigation-contentcontrol
+description: "Implement ContentControl region navigation for dynamic content areas without back stack."
+when_to_use: "Use when swapping content in a specific area of the layout without maintaining back stack, using ContentControl as a navigation target region, or simple content switching that doesn't need navigation history."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: navigation
+---
+
+# Uno Navigation ContentControl — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the ContentControl Navigation Documentation
+
+```
+uno_platform_docs_search("Uno Navigation ContentControl region content switching")
+```
+
+Primary documentation pages:
+- **Define Regions**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRegions.md`
+- **Navigation Region Reference**: `external/uno.extensions/doc/Reference/Navigation/NavigationRegion.md`
+
+Fetch the regions reference:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Reference/Navigation/NavigationRegion.md")
+```
+
+### Step 2: For Alternative Approaches
+
+If the user needs visibility-based switching instead:
+
+See the `uno-navigation-panel-visibility` skill.
+
+## Key Principles (Stable)
+
+- ContentControl can be a navigation target region
+- No back stack — content simply replaced
+- Use `uen:Region.Attached="True"` on the ContentControl
+- Good for sidebar detail panes, settings containers, or single-area content swaps
+
+## Related Skills
+
+- [[uno-navigation-regions]] — Region concepts
+- [[uno-navigation-panel-visibility]] — Visibility-based switching

--- a/skills/uno-navigation-data/SKILL.md
+++ b/skills/uno-navigation-data/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: uno-navigation-data
+description: "Pass and receive data during navigation in Uno Platform applications."
+when_to_use: "Use when passing data (objects, IDs, filters) from one page to another, receiving data in a ViewModel via constructor injection, returning results from a page back to the caller, using `NavigateDataAsync`, `NavigateBackWithResultAsync`, or setting up `DataViewMap` or `ResultDataViewMap` for data-based routes."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: navigation
+---
+
+# Uno Navigation Data Passing — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Data Passing Documentation
+
+```
+uno_platform_docs_search("Uno Navigation data passing receive NavigateDataAsync constructor injection")
+```
+
+Primary documentation pages:
+- **Passing Navigation Data (Chefs)**: `external/uno.chefs/doc/navigation/PassingNavigationData.md`
+- **Pass Data During Navigation**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/DisplayItemDetails.md`
+
+Fetch the Chefs data passing page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.chefs/doc/navigation/PassingNavigationData.md")
+```
+
+### Step 2: For Route Configuration with Data
+
+Data-based navigation requires proper route registration:
+
+```
+uno_platform_docs_search("Uno Navigation DataViewMap ResultDataViewMap route data type")
+```
+
+### Step 3: For Returning Results
+
+If the user needs a round-trip (navigate, pick data, return):
+
+The Chefs page covers `NavigateBackWithResultAsync` and `ResultDataViewMap` patterns.
+
+### Step 4: For XAML Data Passing
+
+For passing data declaratively:
+
+```
+uno_platform_docs_search("Uno Navigation XAML Navigation.Data binding pass")
+```
+
+## Key Principles (Stable)
+
+- Data is received via constructor dependency injection in the target ViewModel
+- `DataViewMap` associates a data type with a View/ViewModel for data-based navigation
+- `ResultDataViewMap` additionally specifies a result type for round-trip navigation
+- `NavigateBackWithResultAsync(data)` returns data to the calling page
+- Routes must be configured in `RegisterRoutes` to support data types
+- `Navigation.Data` attached property enables data passing in XAML
+
+## Related Skills
+
+- [[uno-navigation-routes]] — Route registration with data types
+- [[uno-navigation-code]] — Programmatic navigation methods
+- [[uno-navigation-xaml]] — XAML data binding for navigation

--- a/skills/uno-navigation-dialogs/SKILL.md
+++ b/skills/uno-navigation-dialogs/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: uno-navigation-dialogs
+description: "Display dialogs, flyouts, modals, and message prompts using Uno Platform Navigation Extensions."
+when_to_use: "Use when showing a simple alert, confirmation, or message dialog with OK/Cancel options, getting a user response from a dialog via `ShowMessageDialogAsync`, showing a dialog or flyout via navigation, using `ContentDialog` as a navigation modal, understanding the difference between flyout (Page-based) and modal (ContentDialog-based), or getting results from dialog navigation."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: navigation
+---
+
+# Uno Navigation Dialogs — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Dialog Navigation Documentation
+
+```
+uno_platform_docs_search("Uno Navigation dialogs flyouts ContentDialog modal ShowMessageDialogAsync confirmation alert")
+```
+
+Primary documentation pages:
+- **Display Dialogs as Flyouts or Modals**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/ShowDialog.md`
+- **How-To: Display a Dialog**: `external/uno.extensions/doc/Learn/Navigation/HowTo-ShowDialog.md`
+
+Fetch the walkthrough:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/Walkthrough/ShowDialog.md")
+```
+
+### Step 2: For Simple Message Dialogs
+
+Use `navigator.ShowMessageDialogAsync(...)` for the simplest case — a title, message, and buttons that return the user's choice. No route registration needed.
+
+### Step 3: For Flyout vs Modal
+
+- **Flyout**: navigation target is a `Page` → displayed as flyout
+- **Modal**: navigation target is a `ContentDialog` → displayed as modal
+
+### Step 4: For Dialog Results
+
+If the user needs to return data from a dialog:
+
+See the `uno-navigation-data` skill for `NavigateBackWithResultAsync`.
+
+## Key Principles (Stable)
+
+- Message dialogs are the simplest dialog type — title, message, and buttons via `navigator.ShowMessageDialogAsync(...)`, no route registration required
+- Use `!/` qualifier prefix or `Qualifiers.Dialog` to open a `Page`/`ContentDialog`-based dialog via navigation
+- If the target is a `Page`, it displays as a flyout
+- If the target is a `ContentDialog`, it displays as a modal
+- Dialog results can be returned via `NavigateBackWithResultAsync` (or directly from `ShowMessageDialogAsync` for the simple case)
+- Dialogs participate in the navigation system — they have proper back-stack handling
+
+## Related Skills
+
+- [[uno-navigation-qualifiers]] — Qualifier prefixes
+- [[uno-navigation-data]] — Passing/returning data
+- [[uno-navigation-code]] — Programmatic navigation

--- a/skills/uno-navigation-navigationview/SKILL.md
+++ b/skills/uno-navigation-navigationview/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: uno-navigation-navigationview
+description: "Implement NavigationView navigation in Uno Platform using region-based navigation. Provides complete, compilable shell template for sidebar/hamburger navigation. Use for >5 pages, hierarchical content, or desktop/enterprise apps."
+when_to_use: "Use when more than 5 top-level pages, hierarchical or content-heavy apps, desktop / enterprise apps, prompt mentions \"dashboard\", \"admin\", \"desktop\", \"sidebar\", or \"drawer\", building a sidebar navigation pattern, or implementing a hamburger menu."
+metadata:
+  author: uno-platform
+  version: "3.3"
+  category: navigation
+---
+
+# Uno Navigation with NavigationView — Agent Skill
+
+## Reference Templates
+
+For complete, compilable shell XAML with parameterized placeholders, see:
+
+**`references/shell-navigationview-template.md`** — Contains:
+- Icon lookup table (Home, Search, Settings, Profile, etc.)
+- SHELL_PAGE_NAME.xaml — Without Settings variant
+- SHELL_PAGE_NAME.xaml — With Settings variant
+- SHELL_PAGE_NAME.xaml.cs — Settings code-behind (`Region.SetName` for built-in Settings item)
+- Page template (XAML + code-behind)
+- Route registration template
+- Substitution rules
+- Localization template (Resources.resw)
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the NavigationView Navigation Documentation
+
+```
+uno_platform_docs_search("Uno Navigation NavigationView sidebar hamburger region")
+```
+
+Primary documentation pages:
+- **Define Regions (NavigationView section)**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRegions.md`
+- **Responsive Shell**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/ResponsiveShell.md`
+
+Fetch the define regions page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRegions.md")
+```
+
+Focus on the "Using Regions with NavigationView" section.
+
+### Step 2: For Responsive Navigation
+
+If the user needs adaptive navigation (NavigationView on desktop, TabBar on mobile):
+
+See the `uno-navigation-responsive-shell` skill.
+
+## Key Principles (Stable)
+
+- NavigationView uses region-based navigation to link menu items to content
+- Parent container needs `uen:Region.Attached="True"`
+- NavigationView needs `uen:Region.Attached="True"`
+- Each `NavigationViewItem` uses `uen:Region.Name="RouteName"` to map to content
+- Content area uses a Grid with `uen:Region.Attached="True"` and `uen:Region.Navigator="Visibility"`
+- XAML namespace: `xmlns:uen="using:Uno.Extensions.Navigation.UI"`
+
+## Critical Rules
+
+- The root `Grid` with `uen:Region.Attached="True"` enables region navigation for the entire shell
+- `uen:Region.Attached="True"` MUST also be on the `NavigationView` itself
+- The content area `Grid` inside `NavigationView` needs BOTH `uen:Region.Attached="True"` AND `uen:Region.Navigator="Visibility"`
+- **The content area Grid with `Region.Navigator="Visibility"` must be empty in XAML.** Do not add `Collapsed` child elements for each route. The navigation framework resolves registered routes and injects the corresponding views at runtime.
+- The Settings item is NOT a `NavigationViewItem` in `MenuItems` — use `Loaded` event + `Region.SetName` in code-behind
+- Route names in `RouteMap` MUST match the `uen:Region.Name` values in `SHELL_PAGE_NAME.xaml`
+- Page routes are nested under the `"Main"` route so only the content area updates, not the entire page
+- Do NOT use `Region.Attached="True"` inside `Shell.xaml` — only in `SHELL_PAGE_NAME.xaml`
+
+## Related Skills
+
+- [[uno-navigation-regions]] — Region concepts
+- [[uno-navigation-responsive-shell]] — Adaptive NavigationView + TabBar
+- [[uno-navigation-panel-visibility]] — Visibility-based content switching details
+- [[uno-navigation-tabbar]] — TabBar alternative
+- [[uno-navigation-routes]] — Route registration details

--- a/skills/uno-navigation-navigationview/references/shell-navigationview-template.md
+++ b/skills/uno-navigation-navigationview/references/shell-navigationview-template.md
@@ -1,0 +1,238 @@
+# Shell: Sidebar NavigationView — Reference Templates
+
+Ready-to-use templates for a NavigationView (sidebar/hamburger) navigation shell. Copy, substitute placeholders, and use.
+
+## Icon Lookup Table
+
+| Page Concept | Glyph | Unicode |
+|---|---|---|
+| Home / Dashboard | `&#xE80F;` | `\uE80F` |
+| Search / Explore | `&#xE721;` | `\uE721` |
+| Settings / Gear | `&#xE713;` | `\uE713` |
+| Profile / Person | `&#xE77B;` | `\uE77B` |
+| Favorites / Heart | `&#xE734;` | `\uE734` |
+| Add / Plus | `&#xE710;` | `\uE710` |
+| List / Bullets | `&#xE8FD;` | `\uE8FD` |
+| Chart / Analytics | `&#xE9D9;` | `\uE9D9` |
+| Calendar / Date | `&#xE787;` | `\uE787` |
+| Mail / Messages | `&#xE715;` | `\uE715` |
+| Cart / Shopping | `&#xE7BF;` | `\uE7BF` |
+| Notification / Bell | `&#xEA8F;` | `\uEA8F` |
+
+## Required XAML Namespaces
+
+```xml
+xmlns:uen="using:Uno.Extensions.Navigation.UI"
+```
+
+## SHELL_PAGE_NAME.xaml (Without Settings)
+
+Use this variant when the plan does NOT include a Settings page. The content area Grid with `Region.Navigator="Visibility"` must be **empty** — the navigation framework injects views at runtime from registered routes.
+
+```xml
+<Page x:Class="SHELL_PAGE_CLASS"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:uen="using:Uno.Extensions.Navigation.UI"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid uen:Region.Attached="True">
+        <NavigationView x:Name="NavView"
+                        uen:Region.Attached="True"
+                        IsSettingsVisible="False"
+                        IsBackButtonVisible="Collapsed">
+            <NavigationView.MenuItems>
+                <!-- REPLACE: One NavigationViewItem per page -->
+                <NavigationViewItem uen:Region.Name="PAGE1_NAME"
+                                    Content="PAGE1_LABEL">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="PAGE1_ICON_GLYPH" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem uen:Region.Name="PAGE2_NAME"
+                                    Content="PAGE2_LABEL">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="PAGE2_ICON_GLYPH" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem uen:Region.Name="PAGE3_NAME"
+                                    Content="PAGE3_LABEL">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="PAGE3_ICON_GLYPH" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+            </NavigationView.MenuItems>
+
+            <!-- Content area: visibility-based region switching (empty — framework injects views) -->
+            <Grid uen:Region.Attached="True"
+                  uen:Region.Navigator="Visibility" />
+        </NavigationView>
+    </Grid>
+</Page>
+```
+
+## SHELL_PAGE_NAME.xaml (With Settings)
+
+Use this variant when the plan includes a Settings page. The NavigationView Settings item requires code-behind to set its region name.
+
+```xml
+<Page x:Class="SHELL_PAGE_CLASS"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:uen="using:Uno.Extensions.Navigation.UI"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid uen:Region.Attached="True">
+        <NavigationView x:Name="NavView"
+                        uen:Region.Attached="True"
+                        IsSettingsVisible="True"
+                        IsBackButtonVisible="Collapsed"
+                        Loaded="NavView_Loaded">
+            <NavigationView.MenuItems>
+                <!-- REPLACE: One NavigationViewItem per non-Settings page -->
+                <NavigationViewItem uen:Region.Name="PAGE1_NAME"
+                                    Content="PAGE1_LABEL">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="PAGE1_ICON_GLYPH" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem uen:Region.Name="PAGE2_NAME"
+                                    Content="PAGE2_LABEL">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="PAGE2_ICON_GLYPH" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+            </NavigationView.MenuItems>
+
+            <!-- Content area: visibility-based region switching (empty — framework injects views) -->
+            <Grid uen:Region.Attached="True"
+                  uen:Region.Navigator="Visibility" />
+        </NavigationView>
+    </Grid>
+</Page>
+```
+
+## SHELL_PAGE_NAME.xaml.cs (With Settings — code-behind for Region.SetName)
+
+```csharp
+namespace PAGE_NAMESPACE;
+
+public sealed partial class SHELL_PAGE_NAME : Page
+{
+    public SHELL_PAGE_NAME()
+    {
+        this.InitializeComponent();
+    }
+
+    private void NavView_Loaded(object sender, RoutedEventArgs e)
+    {
+        // The built-in Settings item is not in MenuItems, so we set its Region.Name in code
+        if (NavView.SettingsItem is NavigationViewItem settingsItem)
+        {
+            Uno.Extensions.Navigation.UI.Region.SetName(settingsItem, "Settings");
+        }
+    }
+}
+```
+
+## Page Template (PageName.xaml)
+
+Create one `.xaml` + `.xaml.cs` pair per page in the appropriate project folder.
+
+```xml
+<Page x:Class="PAGE_CLASS"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <TextBlock Text="PAGE_NAME"
+                   FontSize="24"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center" />
+    </Grid>
+</Page>
+```
+
+## Page Template (PageName.xaml.cs)
+
+```csharp
+namespace PAGE_NAMESPACE;
+
+public sealed partial class PAGE_NAMEPage : Page
+{
+    public PAGE_NAMEPage()
+    {
+        this.InitializeComponent();
+    }
+}
+```
+
+## Route Registration (App.xaml.cs)
+
+```csharp
+private static void RegisterRoutes(IViewRegistry views, IRouteRegistry routes)
+{
+    views.Register(
+        new ViewMap(ViewModel: typeof(ShellModel)),
+        new ViewMap<SHELL_PAGE_NAME>(),
+        // REPLACE: One ViewMap per page
+        new ViewMap<PAGE1_NAMEPage>(),
+        new ViewMap<PAGE2_NAMEPage>(),
+        new ViewMap<PAGE3_NAMEPage>()
+    );
+
+    routes.Register(
+        new RouteMap("", View: views.FindByViewModel<ShellModel>(),
+            Nested:
+            [
+                new RouteMap("Main", View: views.FindByView<SHELL_PAGE_NAME>(),
+                    IsDefault: true,
+                    Nested:
+                    [
+                        // REPLACE: One RouteMap per page
+                        new RouteMap("PAGE1_NAME", View: views.FindByView<PAGE1_NAMEPage>(), IsDefault: true),
+                        new RouteMap("PAGE2_NAME", View: views.FindByView<PAGE2_NAMEPage>()),
+                        new RouteMap("PAGE3_NAME", View: views.FindByView<PAGE3_NAMEPage>())
+                    ]
+                )
+            ]
+        )
+    );
+}
+```
+
+## Substitution Rules
+
+1. Replace `SHELL_PAGE_CLASS` with the full `x:Class` value for the shell page (e.g., `MyApp.Presentation.MainPage`)
+2. Replace `SHELL_PAGE_NAME` with the class name of the shell page (e.g., `MainPage`). This is the page that hosts the NavigationView navigation chrome.
+3. Replace `PAGE_CLASS` with the full `x:Class` value for each content page (e.g., `MyApp.Presentation.DashboardPage`)
+4. Replace `PAGE_NAMESPACE` with the namespace for content pages (e.g., `MyApp.Presentation`)
+5. Replace `PAGE1_NAME`, `PAGE2_NAME`, `PAGE3_NAME` with route names from the plan (e.g., `Dashboard`, `Reports`, `Users`)
+6. Replace `PAGE1_LABEL`, `PAGE2_LABEL`, `PAGE3_LABEL` with display labels (or use `x:Uid` for localization)
+7. Replace `PAGE1_ICON_GLYPH`, etc. with glyphs from the Icon Lookup Table above (e.g., `&#xE80F;`)
+8. Add or remove `NavigationViewItem` entries to match the number of pages in the plan
+9. Choose the "With Settings" or "Without Settings" variant based on whether the plan includes a Settings page
+10. If using Settings, include `new RouteMap("Settings", View: views.FindByView<SettingsPage>())` in the nested routes
+
+## Route Registration Rules
+
+1. Route names (first argument to `RouteMap`) MUST match the `uen:Region.Name` values in `SHELL_PAGE_NAME.xaml`
+2. Page routes are nested under the `"Main"` route so only the content area updates, not the entire page
+3. The empty string `""` route is the root shell route
+4. `ViewMap` entries without a ViewModel are valid.
+
+## Localization Template (Strings/en/Resources.resw)
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="PAGE1_NAME_NavItem.Content" xml:space="preserve">
+    <value>PAGE1_LABEL</value>
+  </data>
+  <data name="PAGE1_NAME_NavItem.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>PAGE1_LABEL navigation item</value>
+  </data>
+  <!-- Repeat for each nav item -->
+</root>
+```

--- a/skills/uno-navigation-panel-visibility/SKILL.md
+++ b/skills/uno-navigation-panel-visibility/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: uno-navigation-panel-visibility
+description: "Implement visibility-based navigation using Panel or Grid controls."
+when_to_use: "Use when implementing lightweight content switching without `Frame` overhead via `Region.Navigator=\"Visibility\"`, when serving as the content area inside `TabBar`, `NavigationView`, or responsive shells, or when all registered views should stay in the visual tree after injection."
+metadata:
+  author: uno-platform
+  version: "3.4"
+  category: navigation
+---
+
+# Uno Navigation Panel Visibility — Agent Skill
+
+This skill covers visibility-based navigation where the framework injects registered route views into an empty `Grid` and switches between them by toggling `Visibility`. This is the content-area pattern used inside TabBar, NavigationView, and responsive shell layouts.
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Visibility Navigation Documentation
+
+```
+uno_platform_docs_search("Uno Navigation visibility based panel Grid Region.Navigator content switch")
+```
+
+Primary documentation pages:
+- **Define Regions**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRegions.md`
+- **Navigation Region Reference**: `external/uno.extensions/doc/Reference/Navigation/NavigationRegion.md`
+
+Fetch the define regions walkthrough:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRegions.md")
+```
+
+## Key Principles (Stable)
+
+- Set `uen:Region.Navigator="Visibility"` on the content container Grid
+- Set `uen:Region.Attached="True"` on the same Grid
+- **The Grid marked with `uen:Region.Navigator="Visibility"` must be empty in XAML.** Do not add `Collapsed` child elements for each route. The navigation framework resolves registered routes and injects the corresponding views at runtime.
+- After injection, children are toggled via Visibility — all remain in the visual tree
+- Good for small numbers of views where you want instant switching
+- No back stack — just visibility toggles
+
+## Typical Usage Pattern
+
+The visibility region Grid appears as the content area inside navigation shells:
+
+```xml
+<!-- Inside a TabBar or NavigationView shell -->
+<Grid uen:Region.Attached="True"
+      uen:Region.Navigator="Visibility" />
+```
+
+The framework creates view instances from registered `RouteMap` entries and places them as children of this Grid, managing their `Visibility` as navigation occurs.
+
+## Critical Rules
+
+- The Grid MUST have both `uen:Region.Attached="True"` AND `uen:Region.Navigator="Visibility"`
+- The Grid MUST be empty — do NOT pre-populate with collapsed child elements
+- Route names in `RouteMap` determine which views get injected
+- The parent navigation control (TabBar, NavigationView) drives which child becomes visible
+
+## Related Skills
+
+- [[uno-navigation-regions]] — Region concepts
+- [[uno-navigation-contentcontrol]] — ContentControl-based switching (alternative)
+- [[uno-navigation-navigationview]] — NavigationView shell using visibility regions
+- [[uno-navigation-tabbar]] — TabBar shell using visibility regions
+- [[uno-navigation-responsive-shell]] — Responsive shell using visibility regions

--- a/skills/uno-navigation-qualifiers/SKILL.md
+++ b/skills/uno-navigation-qualifiers/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: uno-navigation-qualifiers
+description: "Use navigation qualifiers in Uno Platform to control back stack behavior."
+when_to_use: "Use when clearing the navigation back stack (e.g., after login), removing specific pages from back stack, opening dialogs/flyouts via navigation, navigating to nested regions, or using qualifier prefixes in route strings."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: navigation
+---
+
+# Uno Navigation Qualifiers — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Qualifiers Documentation
+
+```
+uno_platform_docs_search("Uno Navigation qualifiers back stack clear dialog Qualifiers class")
+```
+
+Primary documentation pages:
+- **Navigation Qualifiers Reference**: `external/uno.extensions/doc/Reference/Navigation/Qualifiers.md`
+- **Advanced Page Navigation**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/AdvancedPageNavigation.md`
+- **XAML Navigation Qualifiers (Chefs)**: `external/uno.chefs/doc/navigation/XamlNavigation.md`
+
+Fetch the qualifiers reference:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Reference/Navigation/Qualifiers.md")
+```
+
+### Step 2: For Advanced Back Stack Management
+
+Fetch the advanced page navigation walkthrough:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/Walkthrough/AdvancedPageNavigation.md")
+```
+
+### Step 3: For Code-Behind Qualifiers
+
+If using qualifiers from code:
+
+```
+uno_platform_docs_search("Uno Navigation Qualifiers.ClearBackStack code behind NavigateViewModelAsync")
+```
+
+Key page:
+- **How-To Advanced Page Navigation**: `external/uno.extensions/doc/Learn/Navigation/Advanced/HowTo-AdvancedPageNavigation.md`
+
+## Key Principles (Stable)
+
+- `-/` prefix: clears back stack (e.g., `uen:Navigation.Request="-/Login"`)
+- `!/` prefix: opens a dialog/flyout
+- Qualifiers can be combined with route names
+- From code: use `Qualifiers.ClearBackStack`, `Qualifiers.Dialog`, etc.
+- `Qualifiers` class is in `Uno.Extensions.Navigation` namespace
+- Common scenario: after login, navigate to main page with `-/` to prevent back navigation to login
+
+## Related Skills
+
+- [[uno-navigation-code]] — Programmatic navigation
+- [[uno-navigation-xaml]] — XAML navigation with qualifiers
+- [[uno-navigation-dialogs]] — Dialog navigation

--- a/skills/uno-navigation-regions/SKILL.md
+++ b/skills/uno-navigation-regions/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: uno-navigation-regions
+description: "Implement region-based navigation in Uno Platform using Region.Attached, Region.Name, and Region.Navigator properties."
+when_to_use: "Use when defining navigation regions within a page, linking a TabBar, NavigationView, or other control to a content area, visibility-based content switching within regions, building navigation hierarchies with nested regions, or using `Region.Attached`, `Region.Name`, and `Region.Navigator`."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: navigation
+---
+
+# Uno Navigation Regions — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Regions Documentation
+
+```
+uno_platform_docs_search("Uno Navigation regions Region.Attached Region.Name navigator")
+```
+
+Primary documentation pages:
+- **Define Regions Walkthrough**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRegions.md`
+- **How-To: Define Regions**: `external/uno.extensions/doc/Learn/Navigation/HowTo-Regions.md`
+- **Navigation Region Reference**: `external/uno.extensions/doc/Reference/Navigation/NavigationRegion.md`
+
+Fetch the walkthrough:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRegions.md")
+```
+
+### Step 2: For Common Pitfalls
+
+Fetch the how-to page for important warnings:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/HowTo-Regions.md")
+```
+
+Critical warning: Do NOT use `Region.Attached="True"` inside Shell.xaml or ExtendedSplashScreen content.
+
+### Step 3: For NavigationView with Regions
+
+The walkthrough includes a section on "Using Regions with NavigationView".
+
+### Step 4: For Visibility-Based Navigation  
+
+If the user needs visibility-based content switching:
+
+See the `uno-navigation-panel-visibility` skill.
+
+## Key Principles (Stable)
+
+- `uen:Region.Attached="True"` — enables region-based navigation on a container
+- `uen:Region.Name="RouteName"` — identifies which route this region represents
+- `uen:Region.Navigator="Visibility"` — switches content by toggling visibility
+- **CRITICAL**: Never use `Region.Attached="True"` inside Shell.xaml content — the navigation host isn't ready yet
+- Regions mirror the navigation control hierarchy
+- Navigation controls (TabBar, NavigationView) and content areas must share a common parent with `Region.Attached="True"`
+
+## Related Skills
+
+- [[uno-navigation-setup]] — Navigation host configuration
+- [[uno-navigation-panel-visibility]] — Visibility-based navigation
+- [[uno-navigation-navigationview]] — NavigationView with regions
+- [[uno-navigation-tabbar]] — TabBar with regions

--- a/skills/uno-navigation-responsive-shell/SKILL.md
+++ b/skills/uno-navigation-responsive-shell/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: uno-navigation-responsive-shell
+description: "Implement responsive navigation shells that adapt between TabBar and NavigationView based on screen size. Provides complete, compilable shell template with VisualStateManager breakpoints."
+when_to_use: "Use when an app must work well on both mobile and desktop, upgrading a single-form-factor shell to responsive, or switching between `TabBar` on mobile and `NavigationView` on desktop via `VisualStateManager` or `ResponsiveExtension`."
+metadata:
+  author: uno-platform
+  version: "3.5"
+  category: navigation
+---
+
+# Uno Navigation Responsive Shell — Agent Skill
+
+## Reference Templates
+
+For a complete, compilable responsive shell XAML with parameterized placeholders, see:
+
+**`references/shell-responsive-template.md`** — Contains:
+- Icon lookup table (Home, Search, Settings, Profile, etc.)
+- SHELL_PAGE_NAME.xaml responsive shell template (NavigationView + TabBar + VisualStateManager)
+- Breakpoint summary table (Narrow / Normal / Wide)
+- Route registration template
+- Substitution rules
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Responsive Shell Documentation
+
+```
+uno_platform_docs_search("Uno Navigation responsive shell NavigationView TabBar adaptive screen size")
+```
+
+Primary documentation page:
+- **Build Responsive Navigation Layouts**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/ResponsiveShell.md`
+
+Fetch the walkthrough:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/Walkthrough/ResponsiveShell.md")
+```
+
+### Step 2: For ResponsiveExtension
+
+If using the Toolkit's `ResponsiveExtension`:
+
+```
+uno_platform_docs_search("Uno Toolkit responsive extension screen size breakpoints")
+```
+
+See also the `uno-toolkit-responsive` skill.
+
+## Key Principles (Stable)
+
+- Use VisualStateManager with adaptive triggers to show/hide different navigation controls
+- Both TabBar and NavigationView can use the same region names for shared content
+- `ResponsiveExtension` can toggle Visibility based on breakpoints (Normal, Wide, etc.)
+- The content area remains the same — only the navigation control changes
+- Common pattern: TabBar at bottom for mobile, NavigationView sidebar for desktop
+- XAML namespaces: `xmlns:uen="using:Uno.Extensions.Navigation.UI"` and `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Breakpoint Summary
+
+| State | Width | TabBar | NavigationView Pane | Use Case |
+|---|---|---|---|---|
+| Narrow | < 700px | Visible | Hidden | Mobile phones |
+| Normal | 700-999px | Hidden | Visible (auto) | Tablets |
+| Wide | >= 1000px | Hidden | Visible (expanded) | Desktops |
+
+## Critical Rules
+
+- Both navigation controls (`NavigationView` and `TabBar`) MUST have `uen:Region.Attached="True"`
+- Both MUST use identical `uen:Region.Name` values for the same pages — they share the content area
+- The `VisualStateManager` goes on the root `Grid` with `uen:Region.Attached="True"`
+- The `Narrow` state has NO `StateTriggers` — it is the default (smallest) state
+- States are ordered by ascending width: Narrow (default) < Normal (700px) < Wide (1000px)
+- The shared content area with `Region.Navigator="Visibility"` serves both navigation controls
+- **The content area Grid with `Region.Navigator="Visibility"` must be empty in XAML.** Do not add `Collapsed` child elements for each route. The navigation framework resolves registered routes and injects the corresponding views at runtime.
+- Do NOT use `Region.Attached="True"` inside `Shell.xaml` — only in `SHELL_PAGE_NAME.xaml`
+
+## Related Skills
+
+- [[uno-navigation-tabbar]] — Mobile-only shell
+- [[uno-navigation-navigationview]] — Desktop-only shell
+- [[uno-navigation-panel-visibility]] — Visibility-based content switching details
+- [[uno-toolkit-responsive]] — Responsive markup extensions
+- [[uno-navigation-regions]] — Region concepts

--- a/skills/uno-navigation-responsive-shell/references/shell-responsive-template.md
+++ b/skills/uno-navigation-responsive-shell/references/shell-responsive-template.md
@@ -1,0 +1,203 @@
+# Shell: Responsive NavigationView + TabBar — Reference Templates
+
+Ready-to-use template for a responsive navigation shell that switches between a bottom TabBar on narrow screens and a sidebar NavigationView on wide screens.
+
+## Icon Lookup Table
+
+| Page Concept | Glyph | Unicode |
+|---|---|---|
+| Home / Dashboard | `&#xE80F;` | `\uE80F` |
+| Search / Explore | `&#xE721;` | `\uE721` |
+| Settings / Gear | `&#xE713;` | `\uE713` |
+| Profile / Person | `&#xE77B;` | `\uE77B` |
+| Favorites / Heart | `&#xE734;` | `\uE734` |
+| Add / Plus | `&#xE710;` | `\uE710` |
+| List / Bullets | `&#xE8FD;` | `\uE8FD` |
+| Chart / Analytics | `&#xE9D9;` | `\uE9D9` |
+| Calendar / Date | `&#xE787;` | `\uE787` |
+| Mail / Messages | `&#xE715;` | `\uE715` |
+
+## Required XAML Namespaces
+
+```xml
+xmlns:uen="using:Uno.Extensions.Navigation.UI"
+xmlns:utu="using:Uno.Toolkit.UI"
+```
+
+## SHELL_PAGE_NAME.xaml (Responsive Shell)
+
+The content area Grid with `Region.Navigator="Visibility"` must be **empty** — the navigation framework injects views at runtime from registered routes.
+
+```xml
+<Page x:Class="SHELL_PAGE_CLASS"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:uen="using:Uno.Extensions.Navigation.UI"
+      xmlns:utu="using:Uno.Toolkit.UI"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid uen:Region.Attached="True">
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup>
+                <!-- Narrow: TabBar visible, NavigationView pane hidden -->
+                <VisualState x:Name="Narrow">
+                    <VisualState.Setters>
+                        <Setter Target="BottomTabs.Visibility" Value="Visible" />
+                        <Setter Target="NavView.IsPaneToggleButtonVisible" Value="False" />
+                        <Setter Target="NavView.PaneDisplayMode" Value="LeftMinimal" />
+                        <Setter Target="NavView.IsPaneOpen" Value="False" />
+                    </VisualState.Setters>
+                </VisualState>
+                <!-- Normal (>=700px): NavigationView visible, TabBar hidden -->
+                <VisualState x:Name="Normal">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="700" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="BottomTabs.Visibility" Value="Collapsed" />
+                        <Setter Target="NavView.IsPaneToggleButtonVisible" Value="True" />
+                        <Setter Target="NavView.IsPaneVisible" Value="True" />
+                        <Setter Target="NavView.PaneDisplayMode" Value="Auto" />
+                    </VisualState.Setters>
+                </VisualState>
+                <!-- Wide (>=1000px): NavigationView expanded -->
+                <VisualState x:Name="Wide">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="1000" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="BottomTabs.Visibility" Value="Collapsed" />
+                        <Setter Target="NavView.IsPaneToggleButtonVisible" Value="True" />
+                        <Setter Target="NavView.IsPaneVisible" Value="True" />
+                        <Setter Target="NavView.PaneDisplayMode" Value="Auto" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+
+        <!-- NavigationView: visible on Normal/Wide, pane hidden on Narrow -->
+        <NavigationView x:Name="NavView"
+                        uen:Region.Attached="True"
+                        IsSettingsVisible="False"
+                        IsBackButtonVisible="Collapsed">
+            <NavigationView.MenuItems>
+                <!-- REPLACE: One NavigationViewItem per page -->
+                <NavigationViewItem uen:Region.Name="PAGE1_NAME"
+                                    Content="PAGE1_LABEL">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="PAGE1_ICON_GLYPH" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem uen:Region.Name="PAGE2_NAME"
+                                    Content="PAGE2_LABEL">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="PAGE2_ICON_GLYPH" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem uen:Region.Name="PAGE3_NAME"
+                                    Content="PAGE3_LABEL">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="PAGE3_ICON_GLYPH" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+            </NavigationView.MenuItems>
+
+            <NavigationView.Content>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <!-- Shared content area: used by both NavigationView and TabBar (empty — framework injects views) -->
+                    <Grid Grid.Row="0"
+                          uen:Region.Attached="True"
+                          uen:Region.Navigator="Visibility" />
+
+                    <!-- Bottom TabBar: visible on Narrow, hidden on Normal/Wide -->
+                    <utu:TabBar x:Name="BottomTabs"
+                                Grid.Row="1"
+                                uen:Region.Attached="True"
+                                Style="{StaticResource BottomTabBarStyle}"
+                                Visibility="Collapsed">
+                        <!-- REPLACE: One TabBarItem per page (must mirror NavigationViewItems) -->
+                        <utu:TabBarItem uen:Region.Name="PAGE1_NAME"
+                                        Content="PAGE1_LABEL"
+                                        Style="{StaticResource MaterialBottomTabBarItemStyle}">
+                            <utu:TabBarItem.Icon>
+                                <FontIcon Glyph="PAGE1_ICON_GLYPH" />
+                            </utu:TabBarItem.Icon>
+                        </utu:TabBarItem>
+                        <utu:TabBarItem uen:Region.Name="PAGE2_NAME"
+                                        Content="PAGE2_LABEL"
+                                        Style="{StaticResource MaterialBottomTabBarItemStyle}">
+                            <utu:TabBarItem.Icon>
+                                <FontIcon Glyph="PAGE2_ICON_GLYPH" />
+                            </utu:TabBarItem.Icon>
+                        </utu:TabBarItem>
+                        <utu:TabBarItem uen:Region.Name="PAGE3_NAME"
+                                        Content="PAGE3_LABEL"
+                                        Style="{StaticResource MaterialBottomTabBarItemStyle}">
+                            <utu:TabBarItem.Icon>
+                                <FontIcon Glyph="PAGE3_ICON_GLYPH" />
+                            </utu:TabBarItem.Icon>
+                        </utu:TabBarItem>
+                    </utu:TabBar>
+                </Grid>
+            </NavigationView.Content>
+        </NavigationView>
+    </Grid>
+</Page>
+```
+
+## Breakpoint Summary
+
+| State | Width | TabBar | NavigationView Pane | Use Case |
+|---|---|---|---|---|
+| Narrow | < 700px | Visible | Hidden | Mobile phones |
+| Normal | 700-999px | Hidden | Visible (auto) | Tablets |
+| Wide | >= 1000px | Hidden | Visible (expanded) | Desktops |
+
+## Route Registration (App.xaml.cs)
+
+Same pattern as TabBar and NavigationView shells:
+
+```csharp
+private static void RegisterRoutes(IViewRegistry views, IRouteRegistry routes)
+{
+    views.Register(
+        new ViewMap(ViewModel: typeof(ShellModel)),
+        new ViewMap<SHELL_PAGE_NAME>(),
+        new ViewMap<PAGE1_NAMEPage>(),
+        new ViewMap<PAGE2_NAMEPage>(),
+        new ViewMap<PAGE3_NAMEPage>()
+    );
+
+    routes.Register(
+        new RouteMap("", View: views.FindByViewModel<ShellModel>(),
+            Nested:
+            [
+                new RouteMap("Main", View: views.FindByView<SHELL_PAGE_NAME>(),
+                    IsDefault: true,
+                    Nested:
+                    [
+                        new RouteMap("PAGE1_NAME", View: views.FindByView<PAGE1_NAMEPage>(), IsDefault: true),
+                        new RouteMap("PAGE2_NAME", View: views.FindByView<PAGE2_NAMEPage>()),
+                        new RouteMap("PAGE3_NAME", View: views.FindByView<PAGE3_NAMEPage>())
+                    ]
+                )
+            ]
+        )
+    );
+}
+```
+
+## Substitution Rules
+
+1. Replace `SHELL_PAGE_CLASS` with the full `x:Class` value for the shell page (e.g., `MyApp.Presentation.MainPage`)
+2. Replace `SHELL_PAGE_NAME` with the class name of the shell page (e.g., `MainPage`). This is the page that hosts the responsive navigation chrome.
+3. Replace `PAGE1_NAME`, `PAGE2_NAME`, `PAGE3_NAME` with route names from the plan
+4. Replace `PAGE1_LABEL`, etc. with display labels
+5. Replace `PAGE1_ICON_GLYPH`, etc. with glyphs from the Icon Lookup Table
+6. Add or remove `NavigationViewItem` + `TabBarItem` pairs as needed
+7. Both `NavigationViewItem` and `TabBarItem` for the same page MUST use the same `uen:Region.Name`

--- a/skills/uno-navigation-routes/SKILL.md
+++ b/skills/uno-navigation-routes/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: uno-navigation-routes
+description: "Define and register navigation routes in Uno Platform applications using ViewMap, DataViewMap, ResultDataViewMap, and RouteMap."
+when_to_use: "Use when registering views and ViewModels for navigation, setting up `ViewMap`, `DataViewMap`, or `ResultDataViewMap`, configuring nested routes and route hierarchies, adding route dependencies or initialization logic, or understanding how routes map to navigation paths."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: navigation
+---
+
+# Uno Navigation Routes — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Routes Documentation
+
+```
+uno_platform_docs_search("Uno Navigation routes ViewMap DataViewMap RouteMap register")
+```
+
+Primary documentation pages:
+- **Define Routes**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRoutes.md`
+- **Register Routes**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/RegisterRoutes.md`
+
+Fetch the define routes page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRoutes.md")
+```
+
+### Step 2: For View-ViewModel Association
+
+Fetch the register routes page for binding views to view models:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/Walkthrough/RegisterRoutes.md")
+```
+
+### Step 3: For Data-Based and Result-Based Navigation
+
+If the user needs to pass data or get results via routes:
+
+```
+uno_platform_docs_search("Uno Navigation DataViewMap ResultDataViewMap data navigation result")
+```
+
+See also the `uno-navigation-data` skill.
+
+## Key Principles (Stable)
+
+- Routes are registered in `App.xaml.cs` via the `RegisterRoutes` method
+- `ViewMap` — associates a View with a ViewModel
+- `DataViewMap` — associates a View/ViewModel with a data type for data-based navigation
+- `ResultDataViewMap` — like DataViewMap but also defines a result type
+- `RouteMap` — defines a named route with nested child routes
+- Route names typically match the page name without the "Page" suffix
+
+## Related Skills
+
+- [[uno-navigation-setup]] — Initial navigation configuration
+- [[uno-navigation-data]] — Passing data during navigation
+- [[uno-navigation-code]] — Programmatic navigation using routes
+- [[uno-navigation-xaml]] — XAML-based navigation using route names

--- a/skills/uno-navigation-setup/SKILL.md
+++ b/skills/uno-navigation-setup/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: uno-navigation-setup
+description: "Set up and configure Uno Platform Navigation Extensions in an application."
+when_to_use: "Use when creating a new Uno Platform project with navigation support, adding navigation to an existing Uno Platform app, configuring `UseNavigation` in App.xaml.cs host builder, setting up route registration, or understanding the relationship between Navigation and Toolkit packages."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: navigation
+---
+
+# Uno Navigation Setup — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Navigation Overview & Setup Documentation
+
+```
+uno_platform_docs_search("Uno Navigation Extensions setup configuration routes UseNavigation")
+```
+
+Primary documentation pages:
+- **Navigation Overview**: `external/uno.extensions/doc/Learn/Navigation/NavigationOverview.md`
+- **Define Routes**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRoutes.md`
+- **Register Routes**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/RegisterRoutes.md`
+
+Fetch the overview page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/NavigationOverview.md")
+```
+
+### Step 2: For Route Registration
+
+Fetch the route registration walkthrough:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRoutes.md")
+```
+
+### Step 3: For Host Builder Configuration
+
+If the user needs the App.xaml.cs setup:
+
+```
+uno_platform_docs_search("Uno Navigation host builder UseNavigation UseToolkitNavigation App.xaml.cs")
+```
+
+## Key Principles (Stable)
+
+- Add `Navigation` to `<UnoFeatures>`: `<UnoFeatures>Navigation;Toolkit</UnoFeatures>`
+- Adding `Toolkit` enables TabBar and NavigationBar controls with navigation support
+- Navigation is configured via the host builder in App.xaml.cs using `.UseNavigation()`
+- Routes are registered using `ViewMap`, `DataViewMap`, or `RouteMap`
+- The navigation host (`Shell.xaml`) is the root of the navigation hierarchy
+- Do NOT use `Region.Attached="True"` inside Shell.xaml or ExtendedSplashScreen content
+
+## Related Skills
+
+- [[uno-navigation-routes]] — Defining and registering routes
+- [[uno-navigation-regions]] — Region-based navigation
+- [[uno-navigation-code]] — Programmatic navigation
+- [[uno-navigation-xaml]] — Declarative XAML navigation

--- a/skills/uno-navigation-tabbar/SKILL.md
+++ b/skills/uno-navigation-tabbar/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: uno-navigation-tabbar
+description: "Implement TabBar navigation in Uno Platform using region-based navigation. Provides complete, compilable shell template for bottom tab navigation. Use for 3-5 top-level pages in mobile-first apps."
+when_to_use: "Use when 3-5 top-level pages, mobile-first / consumer apps, default choice when prompt does not indicate desktop or enterprise, building bottom navigation (mobile), linking TabBar items to content pages via regions, or using TabBar with Navigation Extensions."
+metadata:
+  author: uno-platform
+  version: "3.5"
+  category: navigation
+---
+
+# Uno Navigation with TabBar — Agent Skill
+
+## Reference Templates
+
+For complete, compilable shell XAML with parameterized placeholders, see:
+
+**`references/shell-tabbar-template.md`** — Contains:
+- Icon lookup table (Home, Search, Settings, Profile, etc.)
+- SHELL_PAGE_NAME.xaml shell template with TabBar
+- Page template (XAML + code-behind)
+- Route registration template
+- Substitution rules
+- Localization template (Resources.resw)
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the TabBar Navigation Documentation
+
+```
+uno_platform_docs_search("Uno Navigation TabBar bottom tab region navigation")
+```
+
+Primary documentation pages:
+- **TabBar Navigation (Chefs)**: `external/uno.chefs/doc/toolkit/NavigateTabBar.md`
+- **Define Regions**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/DefineRegions.md`
+
+Fetch the Chefs TabBar page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.chefs/doc/toolkit/NavigateTabBar.md")
+```
+
+### Step 2: For TabBar Control Reference
+
+For TabBar control properties and styling:
+
+```
+uno_platform_docs_search("Uno Toolkit TabBar TabBarItem styles badges")
+```
+
+See also the `uno-toolkit-tabbar` skill for the control itself.
+
+### Step 3: For Responsive Navigation
+
+If combining TabBar (mobile) with NavigationView (desktop):
+
+See the `uno-navigation-responsive-shell` skill.
+
+## Key Principles (Stable)
+
+- TabBar uses region-based navigation similarly to NavigationView
+- Each `TabBarItem` gets `uen:Region.Name="RouteName"`
+- Parent container and content area need `Region.Attached="True"`
+- Apply `BottomTabBarStyle` to the `TabBar`; per-`TabBarItem` styling comes from the active design-theme (e.g., `MaterialBottomTabBarItemStyle` from [[uno-toolkit-material-theme]])
+- Requires `Toolkit` in `<UnoFeatures>` along with `Navigation`
+- XAML namespaces: `xmlns:uen="using:Uno.Extensions.Navigation.UI"` and `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Critical Rules
+
+- The root `Grid` with `uen:Region.Attached="True"` MUST be a direct child of the Page content — it enables region navigation
+- `uen:Region.Navigator="Visibility"` MUST be on the content area Grid — this tells the framework to toggle child visibility
+- **The content area Grid with `Region.Navigator="Visibility"` must be empty in XAML.** Do not add `Collapsed` child elements for each route. The navigation framework resolves registered routes and injects the corresponding views at runtime.
+- `uen:Region.Attached="True"` MUST also be on the TabBar itself
+- Route names in `RouteMap` MUST match the `uen:Region.Name` values in `SHELL_PAGE_NAME.xaml`
+- Tab page routes are nested under the `"Main"` route so only the content area updates, not the entire page
+- Do NOT use `Region.Attached="True"` inside `Shell.xaml` — only in `SHELL_PAGE_NAME.xaml`
+
+## Related Skills
+
+- [[uno-navigation-regions]] — Region concepts
+- [[uno-navigation-responsive-shell]] — Adaptive navigation
+- [[uno-navigation-panel-visibility]] — Visibility-based content switching details
+- [[uno-toolkit-tabbar]] — TabBar control reference
+- [[uno-navigation-navigationview]] — Sidebar navigation alternative
+- [[uno-navigation-routes]] — Route registration details

--- a/skills/uno-navigation-tabbar/references/shell-tabbar-template.md
+++ b/skills/uno-navigation-tabbar/references/shell-tabbar-template.md
@@ -1,0 +1,186 @@
+# Shell: Bottom TabBar — Reference Templates
+
+Ready-to-use templates for a bottom TabBar navigation shell. Copy, substitute placeholders, and use.
+
+## Icon Lookup Table
+
+| Page Concept | Glyph | Unicode |
+|---|---|---|
+| Home / Dashboard | `&#xE80F;` | `\uE80F` |
+| Search / Explore | `&#xE721;` | `\uE721` |
+| Settings / Gear | `&#xE713;` | `\uE713` |
+| Profile / Person | `&#xE77B;` | `\uE77B` |
+| Favorites / Heart | `&#xE734;` | `\uE734` |
+| Add / Plus | `&#xE710;` | `\uE710` |
+| List / Bullets | `&#xE8FD;` | `\uE8FD` |
+| Chart / Analytics | `&#xE9D9;` | `\uE9D9` |
+| Calendar / Date | `&#xE787;` | `\uE787` |
+| Mail / Messages | `&#xE715;` | `\uE715` |
+| Cart / Shopping | `&#xE7BF;` | `\uE7BF` |
+| Notification / Bell | `&#xEA8F;` | `\uEA8F` |
+
+## Required XAML Namespaces
+
+```xml
+xmlns:uen="using:Uno.Extensions.Navigation.UI"
+xmlns:utu="using:Uno.Toolkit.UI"
+```
+
+## SHELL_PAGE_NAME.xaml (Shell)
+
+The content area Grid with `Region.Navigator="Visibility"` must be **empty** — the navigation framework injects views at runtime from registered routes.
+
+```xml
+<Page x:Class="SHELL_PAGE_CLASS"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:uen="using:Uno.Extensions.Navigation.UI"
+      xmlns:utu="using:Uno.Toolkit.UI"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <Grid uen:Region.Attached="True">
+            <Grid.RowDefinitions>
+                <RowDefinition />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <!-- Content area: visibility-based region switching (empty — framework injects views) -->
+            <Grid Grid.Row="0"
+                  uen:Region.Attached="True"
+                  uen:Region.Navigator="Visibility" />
+
+            <!-- Bottom TabBar -->
+            <utu:TabBar Grid.Row="1"
+                        uen:Region.Attached="True"
+                        Style="{StaticResource BottomTabBarStyle}">
+                <!-- REPLACE: One TabBarItem per Tab page -->
+                <utu:TabBarItem uen:Region.Name="PAGE1_NAME"
+                                Content="PAGE1_LABEL"
+                                Style="{StaticResource MaterialBottomTabBarItemStyle}">
+                    <utu:TabBarItem.Icon>
+                        <FontIcon Glyph="PAGE1_ICON_GLYPH" />
+                    </utu:TabBarItem.Icon>
+                </utu:TabBarItem>
+                <utu:TabBarItem uen:Region.Name="PAGE2_NAME"
+                                Content="PAGE2_LABEL"
+                                Style="{StaticResource MaterialBottomTabBarItemStyle}">
+                    <utu:TabBarItem.Icon>
+                        <FontIcon Glyph="PAGE2_ICON_GLYPH" />
+                    </utu:TabBarItem.Icon>
+                </utu:TabBarItem>
+                <utu:TabBarItem uen:Region.Name="PAGE3_NAME"
+                                Content="PAGE3_LABEL"
+                                Style="{StaticResource MaterialBottomTabBarItemStyle}">
+                    <utu:TabBarItem.Icon>
+                        <FontIcon Glyph="PAGE3_ICON_GLYPH" />
+                    </utu:TabBarItem.Icon>
+                </utu:TabBarItem>
+            </utu:TabBar>
+        </Grid>
+    </Grid>
+</Page>
+```
+
+## Page Template (PageName.xaml)
+
+Create one `.xaml` + `.xaml.cs` pair per page in the appropriate project folder.
+
+```xml
+<Page x:Class="PAGE_CLASS"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <TextBlock Text="PAGE_NAME"
+                   FontSize="24"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center" />
+    </Grid>
+</Page>
+```
+
+## Page Template (PageName.xaml.cs)
+
+```csharp
+namespace PAGE_NAMESPACE;
+
+public sealed partial class PAGE_NAMEPage : Page
+{
+    public PAGE_NAMEPage()
+    {
+        this.InitializeComponent();
+    }
+}
+```
+
+## Route Registration (App.xaml.cs)
+
+```csharp
+private static void RegisterRoutes(IViewRegistry views, IRouteRegistry routes)
+{
+    views.Register(
+        new ViewMap(ViewModel: typeof(ShellModel)),
+        new ViewMap<SHELL_PAGE_NAME>(),
+        // REPLACE: One ViewMap per page
+        new ViewMap<PAGE1_NAMEPage>(),
+        new ViewMap<PAGE2_NAMEPage>(),
+        new ViewMap<PAGE3_NAMEPage>()
+    );
+
+    routes.Register(
+        new RouteMap("", View: views.FindByViewModel<ShellModel>(),
+            Nested:
+            [
+                new RouteMap("Main", View: views.FindByView<SHELL_PAGE_NAME>(),
+                    IsDefault: true,
+                    Nested:
+                    [
+                        // REPLACE: One RouteMap per Tab page
+                        new RouteMap("PAGE1_NAME", View: views.FindByView<PAGE1_NAMEPage>(), IsDefault: true),
+                        new RouteMap("PAGE2_NAME", View: views.FindByView<PAGE2_NAMEPage>()),
+                        new RouteMap("PAGE3_NAME", View: views.FindByView<PAGE3_NAMEPage>())
+                    ]
+                )
+            ]
+        )
+    );
+}
+```
+
+## Substitution Rules
+
+1. Replace `SHELL_PAGE_CLASS` with the full `x:Class` value for the shell page (e.g., `MyApp.Presentation.MainPage`)
+2. Replace `SHELL_PAGE_NAME` with the class name of the shell page (e.g., `MainPage`). This is the page that hosts the TabBar navigation chrome.
+3. Replace `PAGE_CLASS` with the full `x:Class` value for each content page (e.g., `MyApp.Presentation.HomePage`)
+4. Replace `PAGE_NAMESPACE` with the namespace for content pages (e.g., `MyApp.Presentation`)
+5. Replace `PAGE1_NAME`, `PAGE2_NAME`, `PAGE3_NAME` with route names from the plan (e.g., `Home`, `Search`, `Profile`)
+6. Replace `PAGE1_LABEL`, `PAGE2_LABEL`, `PAGE3_LABEL` with display labels (or use `x:Uid` for localization)
+7. Replace `PAGE1_ICON_GLYPH`, etc. with glyphs from the Icon Lookup Table above (e.g., `&#xE80F;`)
+8. Add or remove `TabBarItem` entries to match the number of Tab pages in the plan
+9. The `BottomTabBarStyle` goes on the `TabBar` container; `MaterialBottomTabBarItemStyle` goes on each `TabBarItem`
+
+## Route Registration Rules
+
+1. Route names (first argument to `RouteMap`) MUST match the `uen:Region.Name` values in `SHELL_PAGE_NAME.xaml`
+2. Tab page routes are nested under the `"Main"` route so only the content area updates, not the entire page
+3. The empty string `""` route is the root shell route
+4. `ViewMap` entries without a ViewModel are valid
+
+## Localization Template (Strings/en/Resources.resw)
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="PAGE1_NAME_Tab.Content" xml:space="preserve">
+    <value>PAGE1_LABEL</value>
+  </data>
+  <data name="PAGE1_NAME_Tab.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>PAGE1_LABEL tab</value>
+  </data>
+  <!-- Repeat for each tab -->
+</root>
+```
+
+When using `x:Uid`, set `x:Uid="PAGE1_NAME_Tab"` on the `TabBarItem` instead of `Content="PAGE1_LABEL"`.

--- a/skills/uno-navigation-troubleshooting/SKILL.md
+++ b/skills/uno-navigation-troubleshooting/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: uno-navigation-troubleshooting
+description: "Troubleshoot common issues with Uno Platform Navigation Extensions."
+when_to_use: "Use when navigation is not working or throwing errors, pages not loading or blank screens, back navigation not working as expected, region-based navigation issues, route registration errors, or shell.xaml / ExtendedSplashScreen initialization issues."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: navigation
+---
+
+# Uno Navigation Troubleshooting — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Search for Navigation Troubleshooting
+
+```
+uno_platform_docs_search("Uno Navigation troubleshooting errors common issues")
+```
+
+### Step 2: Check Common Pitfalls
+
+Fetch the regions how-to page for critical warnings:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/HowTo-Regions.md")
+```
+
+### Step 3: For Route Registration Issues
+
+```
+uno_platform_docs_search("Uno Navigation route not found register ViewMap DataViewMap")
+```
+
+### Step 4: For Advanced Navigation Issues
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/Advanced/HowTo-AdvancedPageNavigation.md")
+```
+
+## Common Issues (Stable Reference)
+
+1. **Region.Attached in Shell.xaml**: NEVER use `Region.Attached="True"` inside Shell.xaml or ExtendedSplashScreen content — navigation host isn't ready yet
+2. **Missing route registration**: All pages must be registered via `ViewMap`/`DataViewMap` in `RegisterRoutes`
+3. **Missing UnoFeatures**: Ensure `Navigation;Toolkit` are in `<UnoFeatures>`
+4. **Missing XAML namespace**: `xmlns:uen="using:Uno.Extensions.Navigation.UI"` required for regions and attached properties
+5. **Back stack issues**: Use qualifiers (`-/` or `Qualifiers.ClearBackStack`) to manage back stack
+6. **Data not arriving**: Ensure `DataViewMap` is registered for the data type, and ViewModel accepts data via constructor
+
+## Related Skills
+
+- [[uno-navigation-setup]] — Proper setup
+- [[uno-navigation-regions]] — Region configuration
+- [[uno-navigation-routes]] — Route registration

--- a/skills/uno-navigation-xaml/SKILL.md
+++ b/skills/uno-navigation-xaml/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: uno-navigation-xaml
+description: "Implement declarative navigation in Uno Platform XAML using Navigation.Request and Navigation.Data attached properties."
+when_to_use: "Use when adding navigation to buttons, list items, or controls directly in XAML, navigation without writing code-behind, using `uen:Navigation.Request` attached property for route-based navigation, passing data via `uen:Navigation.Data` in XAML, navigation from `ItemsRepeater` or `ListView` item clicks/selections, or simple Frame shell: 1-2 pages, navigation is secondary, no TabBar or NavigationView needed."
+metadata:
+  author: uno-platform
+  version: "3.3"
+  category: navigation
+---
+
+# Uno Navigation via XAML — Agent Skill
+
+## Reference Templates
+
+For a complete, compilable Frame-based shell with parameterized placeholders, see:
+
+**`references/shell-frame-template.md`** — Contains:
+- SHELL_PAGE_NAME.xaml shell template
+- Navigation.Request syntax reference
+- Page template (XAML + code-behind)
+- Route registration template
+- Substitution rules
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the XAML Navigation Documentation
+
+```
+uno_platform_docs_search("Uno Navigation XAML Navigation.Request Navigation.Data attached properties declarative")
+```
+
+Primary documentation pages:
+- **Navigate Using Attached Properties in XAML**: `external/uno.extensions/doc/Learn/Navigation/Walkthrough/NavigateUsingAttachedPropertiesInXAML.md`
+- **XAML Navigation in Chefs**: `external/uno.chefs/doc/navigation/XamlNavigation.md`
+- **Navigation Overview (XAML section)**: `external/uno.extensions/doc/Learn/Navigation/NavigationOverview.md`
+
+Fetch the main walkthrough:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Navigation/Walkthrough/NavigateUsingAttachedPropertiesInXAML.md")
+```
+
+### Step 2: For Chefs App Examples
+
+For real-world XAML navigation patterns:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.chefs/doc/navigation/XamlNavigation.md")
+```
+
+### Step 3: For Qualifiers in XAML
+
+If the user needs back-stack manipulation in XAML (like `-/` to clear):
+
+See the `uno-navigation-qualifiers` skill.
+
+## Key Principles (Stable)
+
+- XAML namespace: `xmlns:uen="using:Uno.Extensions.Navigation.UI"`
+- `uen:Navigation.Request="RouteName"` triggers navigation on interaction (click/tap)
+- `uen:Navigation.Data="{Binding SomeData}"` passes data with the navigation request
+- Works on Button, ListView, ItemsRepeater, and other interactive controls
+- No Click event handler or code-behind needed
+- Supports qualifier prefixes in the route string (e.g., `-/Login` to clear back stack)
+
+## Navigation.Request Syntax
+
+- **Navigate forward**: `uen:Navigation.Request="PageName"` — pushes page onto the frame stack
+- **Navigate and clear back stack**: `uen:Navigation.Request="-/PageName"` — replaces the current page
+- **Navigate back**: `uen:Navigation.Request="!back"` — pops the current page
+- **Navigate to nested region**: `uen:Navigation.Request="./RegionName"` — for visibility-based regions
+
+## Critical Rules
+
+- `uen:Navigation.Request` is an attached property — it works on any UI element that supports `Click` or `Tapped`
+- Navigation happens via XAML only — no code-behind `INavigator` calls needed for simple transitions
+- The `!back` request navigates back in the frame stack
+- The `-/` prefix clears the back stack (use for login-to-home transitions)
+- Route names in `RouteMap` MUST match the `uen:Navigation.Request` values used in XAML
+- Do NOT use `Region.Attached="True"` inside `Shell.xaml` — only in `SHELL_PAGE_NAME.xaml`
+- On secondary pages, always include a back button with `uen:Navigation.Request="!back"`
+
+## Related Skills
+
+- [[uno-navigation-code]] — Programmatic navigation alternative
+- [[uno-navigation-qualifiers]] — Qualifier prefixes
+- [[uno-navigation-routes]] — Route registration
+- [[uno-navigation-data]] — Data passing patterns
+- [[uno-navigation-tabbar]] — Alternative: bottom tab navigation for 3-5 pages
+- [[uno-navigation-navigationview]] — Alternative: sidebar navigation for desktop

--- a/skills/uno-navigation-xaml/references/shell-frame-template.md
+++ b/skills/uno-navigation-xaml/references/shell-frame-template.md
@@ -1,0 +1,128 @@
+# Shell: Simple Frame — Reference Templates
+
+Ready-to-use templates for a simple Frame-based navigation shell. Copy, substitute placeholders, and use.
+
+## SHELL_PAGE_NAME.xaml (Shell)
+
+```xml
+<Page x:Class="SHELL_PAGE_CLASS"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:uen="using:Uno.Extensions.Navigation.UI"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <!-- REPLACE: Build your main page content here -->
+        <!-- Use uen:Navigation.Request on buttons to navigate to other pages -->
+        <StackPanel HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Spacing="16">
+            <TextBlock Text="APP_TITLE"
+                       FontSize="32"
+                       HorizontalAlignment="Center" />
+            <!-- REPLACE: One button per navigable page -->
+            <Button Content="Go to PAGE2_LABEL"
+                    HorizontalAlignment="Center"
+                    uen:Navigation.Request="PAGE2_NAME" />
+        </StackPanel>
+    </Grid>
+</Page>
+```
+
+## Navigation.Request Syntax
+
+- **Navigate forward**: `uen:Navigation.Request="PageName"` — pushes page onto the frame stack
+- **Navigate and clear back stack**: `uen:Navigation.Request="-/PageName"` — replaces the current page
+- **Navigate back**: `uen:Navigation.Request="!back"` — pops the current page
+- **Navigate to nested region**: `uen:Navigation.Request="./RegionName"` — for visibility-based regions
+
+## Page Template (PageName.xaml)
+
+Create one `.xaml` + `.xaml.cs` pair per page in the appropriate project folder.
+
+```xml
+<Page x:Class="PAGE_CLASS"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:uen="using:Uno.Extensions.Navigation.UI"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition />
+        </Grid.RowDefinitions>
+
+        <!-- Top bar with back button -->
+        <Button Content="Back"
+                uen:Navigation.Request="!back"
+                Margin="8" />
+
+        <!-- REPLACE: Page content goes here -->
+        <Grid Grid.Row="1">
+            <TextBlock Text="PAGE_NAME"
+                       FontSize="24"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center" />
+        </Grid>
+    </Grid>
+</Page>
+```
+
+## Page Template (PageName.xaml.cs)
+
+```csharp
+namespace PAGE_NAMESPACE;
+
+public sealed partial class PAGE_NAMEPage : Page
+{
+    public PAGE_NAMEPage()
+    {
+        this.InitializeComponent();
+    }
+}
+```
+
+## Route Registration (App.xaml.cs)
+
+Add to the existing `RegisterRoutes` method:
+
+```csharp
+private static void RegisterRoutes(IViewRegistry views, IRouteRegistry routes)
+{
+    views.Register(
+        new ViewMap(ViewModel: typeof(ShellModel)),
+        new ViewMap<SHELL_PAGE_NAME>(),
+        // REPLACE: One ViewMap per page
+        new ViewMap<PAGE2_NAMEPage>()
+    );
+
+    routes.Register(
+        new RouteMap("", View: views.FindByViewModel<ShellModel>(),
+            Nested:
+            [
+                new RouteMap("Main", View: views.FindByView<SHELL_PAGE_NAME>(),
+                    IsDefault: true,
+                    Nested:
+                    [
+                        // REPLACE: One RouteMap per secondary page
+                        new RouteMap("PAGE2_NAME", View: views.FindByView<PAGE2_NAMEPage>())
+                    ]
+                )
+            ]
+        )
+    );
+}
+```
+
+## Substitution Rules
+
+1. Replace `SHELL_PAGE_CLASS` with the full `x:Class` value for the shell page (e.g., `MyApp.Presentation.MainPage`)
+2. Replace `SHELL_PAGE_NAME` with the class name of the shell page (e.g., `MainPage`). This is the page that hosts the primary navigation content.
+3. Replace `PAGE_CLASS` with the full `x:Class` value for each content page (e.g., `MyApp.Presentation.DetailPage`)
+4. Replace `PAGE_NAMESPACE` with the namespace for content pages (e.g., `MyApp.Presentation`)
+5. Replace `APP_TITLE` with the app name from the plan
+6. Replace `PAGE2_NAME` with the route name of the secondary page (e.g., `Detail`)
+7. Replace `PAGE2_LABEL` with the display label (e.g., `"View Details"`)
+8. Add more `Button` + `Navigation.Request` pairs for additional pages
+9. On secondary pages, always include a back button with `uen:Navigation.Request="!back"`

--- a/skills/uno-testing-assertions/SKILL.md
+++ b/skills/uno-testing-assertions/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 # Uno Platform Test Assertions Skill
 
-> **Prerequisite:** This skill requires the **Uno App MCP** (the `uno_app_*` tools), provided by the Uno tooling / Uno Platform Dev Server. It is a separate server from the documentation MCP used by other skills. Before proceeding, confirm the `uno_app_*` tools are available; if they are not, stop and tell the user to enable the Uno tooling rather than attempting to test without them.
+> **Prerequisite:** This skill requires the **Uno App MCP** (the `uno_app_*` tools), provided by the Uno tooling. It is a separate server from the documentation MCP used by other skills. Before proceeding, confirm the `uno_app_*` tools are available; if they are not, stop and tell the user to enable the Uno tooling rather than attempting to test without them.
 
 This skill provides patterns for validating UI state and asserting test conditions when testing Uno Platform applications with the Uno App MCP tools.
 

--- a/skills/uno-testing-assertions/SKILL.md
+++ b/skills/uno-testing-assertions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uno-testing-assertions
-description: "Provides assertion and validation patterns for UI testing of Uno Platform applications."
+description: "Provides assertion and validation patterns for UI testing of Uno Platform applications with the Uno App MCP server tools."
 when_to_use: "Use this skill when you need to validate UI state, verify element properties, compare screenshots, or assert on data binding values during automated testing. Complements the ui-testing skill with validation-specific guidance."
 compatibility: Requires the Uno App MCP server to be configured. Use alongside the ui-testing skill for complete test coverage.
 metadata:
@@ -10,6 +10,8 @@ metadata:
 ---
 
 # Uno Platform Test Assertions Skill
+
+> **Prerequisite:** This skill requires the **Uno App MCP** (the `uno_app_*` tools), provided by the Uno tooling / Uno Platform Dev Server. It is a separate server from the documentation MCP used by other skills. Before proceeding, confirm the `uno_app_*` tools are available; if they are not, stop and tell the user to enable the Uno tooling rather than attempting to test without them.
 
 This skill provides patterns for validating UI state and asserting test conditions when testing Uno Platform applications with the Uno App MCP tools.
 

--- a/skills/uno-testing-assertions/SKILL.md
+++ b/skills/uno-testing-assertions/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: uno-testing-assertions
+description: "Provides assertion and validation patterns for UI testing of Uno Platform applications."
+when_to_use: "Use this skill when you need to validate UI state, verify element properties, compare screenshots, or assert on data binding values during automated testing. Complements the ui-testing skill with validation-specific guidance."
+compatibility: Requires the Uno App MCP server to be configured. Use alongside the ui-testing skill for complete test coverage.
+metadata:
+  author: uno-platform
+  version: "1.3"
+  category: testing
+---
+
+# Uno Platform Test Assertions Skill
+
+This skill provides patterns for validating UI state and asserting test conditions when testing Uno Platform applications with the Uno App MCP tools.
+
+## Assertion Types
+
+### Visual Assertions (Screenshots)
+
+Use `uno_app_get_screenshot` to capture visual state:
+
+```
+uno_app_get_screenshot(fileType: "png", quality: 100, path: "/path/to/screenshot.png")
+```
+
+**Validation approaches:**
+1. **Visual comparison**: Compare with baseline images
+2. **Manual review**: Save screenshots for human inspection
+3. **AI-assisted validation**: Describe expected visual state and verify
+
+### Structure Assertions (Visual Tree)
+
+Use `uno_app_visualtree_snapshot` to verify UI structure:
+
+**Assert element exists:**
+- Get visual tree snapshot
+- Search for element by name, AutomationId, or type
+- Fail if element not found
+
+**Assert element not visible:**
+- Get tree with `includeHidden: false`
+- Verify element is NOT in the returned tree
+
+**Assert element visible:**
+- Get tree with `includeHidden: false`
+- Verify element IS in the returned tree
+
+### Property Assertions
+
+From visual tree, check element properties:
+
+| Property | What to Check |
+|----------|---------------|
+| `IsEnabled` | Element can be interacted with |
+| `IsChecked` | Checkbox/Toggle state |
+| `Content` | Button/Label text |
+| `Text` | TextBox/TextBlock content |
+| `SelectedIndex` | ComboBox/List selection |
+| `Value` | Slider/ProgressBar value |
+
+### Data Assertions
+
+Use `uno_app_get_element_datacontext` to validate bound data:
+
+```
+uno_app_get_element_datacontext(elementRef: "element_handle")
+```
+
+Verify:
+- ViewModel property values
+- Collection counts and items
+- Computed properties
+- State flags
+
+## Common Assertion Patterns
+
+### Assert Page Loaded
+
+```
+1. uno_app_visualtree_snapshot(justMyCode: true)
+2. Search for expected page/view element
+3. Verify page-specific elements exist
+4. Optionally capture screenshot for visual confirmation
+```
+
+### Assert Button State
+
+```
+1. uno_app_visualtree_snapshot(justMyCode: true)
+2. Find button by name or AutomationId
+3. Check IsEnabled property
+4. Verify Content matches expected text
+```
+
+### Assert Text Content
+
+```
+1. uno_app_visualtree_snapshot(justMyCode: true)
+2. Find TextBlock/TextBox element
+3. Verify Text property matches expected value
+```
+
+### Assert List Items
+
+```
+1. uno_app_visualtree_snapshot(justMyCode: true)
+2. Find ListView/ItemsRepeater element
+3. Count child items
+4. Verify expected count
+5. Check item content if needed
+```
+
+### Assert Dialog Displayed
+
+```
+1. uno_app_visualtree_snapshot(justMyCode: true)
+2. Search for ContentDialog or Popup element
+3. Verify dialog-specific content exists
+4. Capture screenshot for visual confirmation
+```
+
+### Assert Form Validation Errors
+
+```
+1. Enter invalid data in form
+2. Attempt to submit
+3. uno_app_visualtree_snapshot(justMyCode: true)
+4. Look for validation error TextBlocks
+5. Verify error messages match expected text
+```
+
+### Assert Navigation Occurred
+
+```
+1. Trigger navigation action
+2. uno_app_visualtree_snapshot(justMyCode: true)
+3. Verify previous page elements are gone
+4. Verify new page elements are present
+```
+
+## Screenshot-Based Assertions
+
+### Capturing for Comparison
+
+```
+uno_app_get_screenshot(
+  fileType: "png",
+  quality: 100,
+  path: "/tests/screenshots/test_case_name.png"
+)
+```
+
+### Assertion Strategies
+
+**Pixel-perfect comparison:**
+- Use when UI is deterministic
+- Be aware of anti-aliasing differences
+- May need tolerance threshold
+
+**Region comparison:**
+- Compare specific areas of interest
+- Ignore dynamic content regions
+- Focus on stable UI elements
+
+**Semantic comparison:**
+- Describe what should be visible
+- Verify key visual elements
+- Allow for minor variations
+
+### Handling Dynamic Content
+
+When screenshots contain dynamic data:
+1. Use data mocking/seeding
+2. Focus assertions on static elements
+3. Mask dynamic regions
+4. Use structural validation instead
+
+## Data Context Assertions
+
+### Verify ViewModel State
+
+```
+1. Get element handle from visual tree
+2. uno_app_get_element_datacontext(elementRef: "handle")
+3. Parse returned XML
+4. Assert property values match expected state
+```
+
+### Example Assertions
+
+**Assert user is logged in:**
+- Get DataContext of user info element
+- Verify `IsLoggedIn: true`
+- Verify `Username` has value
+
+**Assert item count:**
+- Get DataContext with collection property
+- Verify collection count matches expected
+
+**Assert computed state:**
+- Get DataContext after action
+- Verify derived/computed properties updated
+
+## Timing and Retry Patterns
+
+### Wait for Condition
+
+When UI updates asynchronously:
+
+```
+Loop (max N attempts):
+  1. Get visual tree snapshot
+  2. Check for expected condition
+  3. If condition met, break
+  4. Wait brief interval
+  5. Retry
+Fail if condition not met after all attempts
+```
+
+### Wait for Element
+
+```
+Retry up to 10 times:
+  1. uno_app_visualtree_snapshot(justMyCode: true)
+  2. Search for expected element
+  3. If found, return success
+  4. Wait 500ms
+  5. Retry
+Fail with "Element not found" if all retries exhausted
+```
+
+### Wait for Loading Complete
+
+```
+Retry until no loading indicators:
+  1. uno_app_visualtree_snapshot(justMyCode: true)
+  2. Search for ProgressRing, ProgressBar, loading text
+  3. If none found, loading complete
+  4. Wait 500ms
+  5. Retry
+```
+
+## Failure Handling
+
+### Capture Diagnostic Info
+
+On assertion failure:
+1. Capture screenshot for visual debugging
+2. Get full visual tree (justMyCode: false)
+3. Log expected vs actual values
+4. Save DataContext if relevant
+
+### Common Failure Causes
+
+| Failure | Likely Cause | Resolution |
+|---------|--------------|------------|
+| Element not found | Timing issue | Add retry/wait |
+| Wrong property value | State not updated | Wait for async complete |
+| Screenshot mismatch | Dynamic content | Use data seeding or masking |
+| Stale handle | Tree changed | Refresh visual tree |
+
+## Test Organization Tips
+
+### Before Each Test
+1. Ensure app is running: `uno_app_get_runtime_info`
+2. Navigate to known initial state
+3. Clear any persistent test data
+
+### After Each Test
+1. Capture final screenshot (pass or fail)
+2. Reset app state if possible
+3. Log assertion results
+
+### On Failure
+1. Capture diagnostic screenshot
+2. Dump visual tree
+3. Save DataContext of relevant elements
+4. Preserve failure artifacts for debugging
+
+## Best Practices
+
+1. **Be specific**: Assert on exact values, not just existence
+2. **Use proper identifiers**: Rely on AutomationId over generated names
+3. **Handle timing**: Always account for async operations
+4. **Capture evidence**: Screenshots on both pass and fail
+5. **Test independence**: Each test should set up its own state
+6. **Meaningful messages**: Include context in failure messages

--- a/skills/uno-testing-ui/SKILL.md
+++ b/skills/uno-testing-ui/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: uno-testing-ui
+description: "Automates UI testing for Uno Platform applications using the Uno App MCP server tools."
+when_to_use: "Use this skill when performing automated UI testing, visual validation, interaction testing, or end-to-end testing of Uno Platform cross-platform applications. Covers app lifecycle management, visual tree inspection, element interaction, screenshot capture, and test assertions."
+compatibility: Requires the Uno App MCP server to be configured and available. Works with Uno Platform applications targeting desktop (Windows, macOS, Linux), WebAssembly, iOS, and Android.
+metadata:
+  author: uno-platform
+  version: "1.3"
+  category: testing
+---
+
+# Uno Platform UI Testing Agent Skill
+
+This skill enables automated UI testing of Uno Platform applications using the Uno App MCP server tools. It provides comprehensive guidance for launching apps, inspecting UI elements, simulating user interactions, and validating visual output.
+
+## Overview
+
+The Uno App MCP server exposes a set of tools that allow agents to:
+- Start and stop Uno Platform applications
+- Capture screenshots for visual validation
+- Inspect the visual tree to discover UI elements
+- Interact with elements using automation peers
+- Simulate keyboard and pointer input
+- Retrieve element data context for state validation
+
+## Prerequisites
+
+1. The Uno App MCP server must be configured in your environment
+2. The target application must be an Uno Platform project with MCP client integration
+3. The project must have valid target frameworks (e.g., `net9.0-desktop`, `net9.0-browserwasm`)
+
+## Quick Start Workflow
+
+For most UI testing scenarios, follow this workflow:
+
+1. **Start the app** → `uno_app_start`
+2. **Verify app is running** → `uno_app_get_runtime_info`
+3. **Capture initial screenshot** → `uno_app_get_screenshot`
+4. **Get visual tree** → `uno_app_visualtree_snapshot`
+5. **Interact with elements** → `uno_app_element_peer_default_action` or input tools
+6. **Validate results** → Screenshots + visual tree inspection
+7. **Close the app** → `uno_app_close`
+
+## Available MCP Tools
+
+### App Lifecycle Tools
+
+| Tool | Description |
+|------|-------------|
+| `uno_app_start` | Starts the application in debug mode with Hot Reload |
+| `uno_app_get_runtime_info` | Gets runtime info (PID, window title, platform, uptime) |
+| `uno_app_close` | Terminates the running application (desktop only) |
+
+### Visual Inspection Tools
+
+| Tool | Description |
+|------|-------------|
+| `uno_app_get_screenshot` | Captures a screenshot for visual validation |
+| `uno_app_visualtree_snapshot` | Gets XML visual tree snapshot with element handles |
+| `uno_app_get_element_datacontext` | Gets the DataContext of a specific element |
+
+### Interaction Tools
+
+| Tool | Description |
+|------|-------------|
+| `uno_app_element_peer_default_action` | Invokes the default automation action on an element |
+| `uno_app_element_peer_action` | Invokes a specific automation peer action |
+| `uno_app_pointer_click` | Performs pointer click at coordinates |
+| `uno_app_key_press` | Presses a keyboard key |
+| `uno_app_type_text` | Types text using keyboard simulation |
+
+### Diagnostic Tools
+
+| Tool | Description |
+|------|-------------|
+| `uno_app_get_memory_counters` | Gets memory diagnostics for the running app |
+
+## Detailed Tool Usage
+
+### Starting an Application
+
+Use `uno_app_start` to launch the application:
+
+```
+Tool: uno_app_start
+Parameters:
+  - projectPath: Full path to the .csproj file (must be within MCP working directory)
+  - targetFramework: Target framework moniker (e.g., "net9.0-desktop", "net9.0-browserwasm")
+  - args: Optional command-line arguments (array)
+```
+
+**Example scenarios:**
+- Desktop testing: `targetFramework = "net9.0-desktop"`
+- WebAssembly testing: `targetFramework = "net9.0-browserwasm"`
+
+**Important:** Always verify the app started successfully by calling `uno_app_get_runtime_info` afterward.
+
+### Inspecting the Visual Tree
+
+Use `uno_app_visualtree_snapshot` to get an XML representation of the UI:
+
+```
+Tool: uno_app_visualtree_snapshot
+Parameters:
+  - justMyCode: Filter to user-defined elements only (default: true)
+  - includeBounds: Include element bounds for coordinate-based interaction (default: false)
+  - includeHidden: Include hidden/collapsed elements (default: false)
+```
+
+The returned XML contains element handles (refs) that can be used with interaction tools. Each element includes:
+- Element type and name
+- Automation properties
+- Handle/reference for interactions
+- Bounds (if requested)
+
+**Tip:** Set `justMyCode: true` to reduce noise from framework elements and focus on application UI.
+
+### Interacting with Elements
+
+**Preferred approach:** Use automation peers when element handles are available.
+
+1. **Default Action** (most common):
+   ```
+   Tool: uno_app_element_peer_default_action
+   Parameters:
+     - elementRef: Handle from visual tree snapshot
+   ```
+   This invokes the natural action (click for buttons, toggle for checkboxes, etc.)
+
+2. **Specific Action** (for advanced scenarios):
+   ```
+   Tool: uno_app_element_peer_action
+   Parameters:
+     - elementRef: Handle from visual tree snapshot
+     - action: Specific automation action name
+     - actionParameters: Optional parameters array
+   ```
+
+**Fallback approach:** Use coordinate-based input when handles aren't suitable.
+
+3. **Pointer Click**:
+   ```
+   Tool: uno_app_pointer_click
+   Parameters:
+     - x: Absolute physical X coordinate
+     - y: Absolute physical Y coordinate
+     - button: "left", "middle", or "right"
+     - clickCount: Number of clicks (default: 1)
+     - delayBetweenPresseAndReleaseInMs: Delay in milliseconds (default: 10)
+   ```
+
+4. **Keyboard Input**:
+   ```
+   Tool: uno_app_key_press
+   Parameters:
+     - virtualKey: VirtualKey name (e.g., "Enter", "Tab", "A")
+     - virtualKeyModifiers: Optional modifiers ("control", "shift", "menu", "windows")
+     - unicodeKey: Optional explicit unicode character
+   ```
+
+5. **Text Entry**:
+   ```
+   Tool: uno_app_type_text
+   Parameters:
+     - text: String of text to type
+     - intervalInMs: Delay between key presses
+   ```
+
+### Capturing Screenshots
+
+Use `uno_app_get_screenshot` for visual validation:
+
+```
+Tool: uno_app_get_screenshot
+Parameters:
+  - fileType: "png" or "jpeg"
+  - quality: Image quality 1-100 (default: 75)
+  - path: Optional file path to save the screenshot
+```
+
+Screenshots are essential for:
+- Visual regression testing
+- Documenting test execution
+- Debugging failed tests
+- Validating layout and styling
+
+### Validating Element State
+
+Use `uno_app_get_element_datacontext` to inspect bound data:
+
+```
+Tool: uno_app_get_element_datacontext
+Parameters:
+  - elementRef: Handle from visual tree snapshot
+```
+
+Returns an XML representation of the element's DataContext, useful for verifying:
+- ViewModel state
+- Data binding correctness
+- Business logic results
+
+## Testing Patterns
+
+### Pattern 1: Simple Click Test
+
+1. Start the app
+2. Get visual tree snapshot
+3. Find the target button by name/type
+4. Call `uno_app_element_peer_default_action` with its handle
+5. Get new visual tree or screenshot
+6. Verify expected changes
+
+### Pattern 2: Form Input Test
+
+1. Start the app
+2. Navigate to the form (if needed)
+3. Get visual tree to find input fields
+4. For each field:
+   - Call `uno_app_element_peer_default_action` to focus
+   - Call `uno_app_type_text` to enter data
+5. Submit the form
+6. Validate results via screenshot or data context
+
+### Pattern 3: Navigation Test
+
+1. Start the app
+2. Get initial visual tree snapshot
+3. Trigger navigation (click nav button, etc.)
+4. Wait briefly for navigation to complete
+5. Get new visual tree snapshot
+6. Verify the expected page/view is displayed
+
+### Pattern 4: Visual Regression Test
+
+1. Start the app
+2. Navigate to target state
+3. Capture screenshot with `uno_app_get_screenshot`
+4. Compare with baseline image
+5. Report differences
+
+## Best Practices
+
+### Element Selection
+- **Prefer automation peers** over coordinate clicks for reliability
+- Use `justMyCode: true` to filter framework elements
+- Look for elements with `x:Name` or `AutomationProperties.AutomationId`
+
+### Test Stability
+- Always verify app is running with `uno_app_get_runtime_info` before testing
+- Add brief delays between rapid interactions if needed
+- Refresh visual tree after actions that change UI state
+
+### Assertions
+- Use screenshots for visual validation
+- Use `uno_app_get_element_datacontext` for data validation
+- Check visual tree for element presence/absence
+
+### Cleanup
+- Always call `uno_app_close` at the end of tests (desktop)
+- Handle test failures gracefully with cleanup
+
+## Troubleshooting
+
+### "No connected app instance"
+- The app hasn't started or has crashed
+- Call `uno_app_start` to launch the app
+- Check build output for errors
+
+### Element not found in visual tree
+- Element may be hidden/collapsed (try `includeHidden: true`)
+- Element may be dynamically created (refresh the tree)
+- Check if using correct framework filter
+
+### Interaction not working
+- Verify element handle is from latest tree snapshot
+- Check if element is enabled and visible
+- Try coordinate-based input as fallback
+
+### Screenshots are blank or incorrect
+- Ensure app window is visible and not minimized
+- Check for correct target framework
+- Verify app has finished rendering
+
+## References
+
+For detailed implementation patterns, see:
+- [references/INTERACTION-PATTERNS.md](references/INTERACTION-PATTERNS.md) - Detailed interaction examples
+- [references/VISUAL-TREE-GUIDE.md](references/VISUAL-TREE-GUIDE.md) - Visual tree inspection guide

--- a/skills/uno-testing-ui/SKILL.md
+++ b/skills/uno-testing-ui/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 # Uno Platform UI Testing Agent Skill
 
-> **Prerequisite:** This skill requires the **Uno App MCP** (the `uno_app_*` tools), provided by the Uno tooling / Uno Platform Dev Server. It is a separate server from the documentation MCP used by other skills. Before proceeding, confirm the `uno_app_*` tools are available; if they are not, stop and tell the user to enable the Uno tooling rather than attempting to test without them.
+> **Prerequisite:** This skill requires the **Uno App MCP** (the `uno_app_*` tools), provided by the Uno tooling. It is a separate server from the documentation MCP used by other skills. Before proceeding, confirm the `uno_app_*` tools are available; if they are not, stop and tell the user to enable the Uno tooling rather than attempting to test without them.
 
 This skill enables automated UI testing of Uno Platform applications using the Uno App MCP server tools. It provides comprehensive guidance for launching apps, inspecting UI elements, simulating user interactions, and validating visual output.
 

--- a/skills/uno-testing-ui/SKILL.md
+++ b/skills/uno-testing-ui/SKILL.md
@@ -11,6 +11,8 @@ metadata:
 
 # Uno Platform UI Testing Agent Skill
 
+> **Prerequisite:** This skill requires the **Uno App MCP** (the `uno_app_*` tools), provided by the Uno tooling / Uno Platform Dev Server. It is a separate server from the documentation MCP used by other skills. Before proceeding, confirm the `uno_app_*` tools are available; if they are not, stop and tell the user to enable the Uno tooling rather than attempting to test without them.
+
 This skill enables automated UI testing of Uno Platform applications using the Uno App MCP server tools. It provides comprehensive guidance for launching apps, inspecting UI elements, simulating user interactions, and validating visual output.
 
 ## Overview

--- a/skills/uno-testing-ui/references/INTERACTION-PATTERNS.md
+++ b/skills/uno-testing-ui/references/INTERACTION-PATTERNS.md
@@ -1,0 +1,265 @@
+# Interaction Patterns Reference
+
+This document provides detailed examples of common UI interaction patterns using the Uno App MCP tools.
+
+## Button Interactions
+
+### Clicking a Button by Handle
+
+The most reliable way to click a button:
+
+1. Get the visual tree:
+   ```
+   uno_app_visualtree_snapshot(justMyCode: true, includeBounds: false, includeHidden: false)
+   ```
+
+2. Parse the XML to find the button element. Example output:
+   ```xml
+   <Button x:Name="SubmitButton" handle="btn_001" Content="Submit" />
+   ```
+
+3. Invoke the default action:
+   ```
+   uno_app_element_peer_default_action(elementRef: "btn_001")
+   ```
+
+### Double-Click Scenarios
+
+For elements requiring double-click, use pointer click:
+
+```
+uno_app_pointer_click(x: 250, y: 100, button: "left", clickCount: 2, delayBetweenPresseAndReleaseInMs: 50)
+```
+
+## Text Input
+
+### Entering Text in a TextBox
+
+1. Find the TextBox in the visual tree
+2. Focus the element:
+   ```
+   uno_app_element_peer_default_action(elementRef: "textbox_handle")
+   ```
+3. Type the text:
+   ```
+   uno_app_type_text(text: "Hello World", intervalInMs: 50)
+   ```
+
+### Clearing a TextBox
+
+1. Focus the TextBox
+2. Select all text:
+   ```
+   uno_app_key_press(virtualKey: "A", virtualKeyModifiers: "control")
+   ```
+3. Delete:
+   ```
+   uno_app_key_press(virtualKey: "Delete")
+   ```
+
+### Entering Special Characters
+
+Use `unicodeKey` for characters not easily represented by virtual keys:
+
+```
+uno_app_key_press(virtualKey: "None", unicodeKey: "€")
+```
+
+## Keyboard Navigation
+
+### Tab Navigation
+
+Move focus between elements:
+```
+uno_app_key_press(virtualKey: "Tab")
+```
+
+Move backwards:
+```
+uno_app_key_press(virtualKey: "Tab", virtualKeyModifiers: "shift")
+```
+
+### Enter to Submit
+
+Press Enter on focused button or form:
+```
+uno_app_key_press(virtualKey: "Enter")
+```
+
+### Escape to Cancel
+
+Close dialogs or cancel operations:
+```
+uno_app_key_press(virtualKey: "Escape")
+```
+
+## List and Selection Interactions
+
+### Selecting an Item in a ListView
+
+1. Get the visual tree to find list items
+2. Use default action on the item:
+   ```
+   uno_app_element_peer_default_action(elementRef: "listitem_handle")
+   ```
+
+### Multi-Select with Ctrl+Click
+
+For lists that support multi-selection:
+
+1. Click first item normally
+2. For additional items:
+   ```
+   uno_app_pointer_click(x: 150, y: 200, button: "left")
+   ```
+
+### Keyboard List Navigation
+
+Navigate in lists using arrow keys:
+```
+uno_app_key_press(virtualKey: "Down")
+uno_app_key_press(virtualKey: "Up")
+```
+
+## ComboBox/Dropdown Interactions
+
+### Opening a ComboBox
+
+```
+uno_app_element_peer_default_action(elementRef: "combobox_handle")
+```
+
+### Selecting an Item
+
+After opening:
+1. Use arrow keys to navigate:
+   ```
+   uno_app_key_press(virtualKey: "Down")
+   ```
+2. Press Enter to select:
+   ```
+   uno_app_key_press(virtualKey: "Enter")
+   ```
+
+## Checkbox and ToggleSwitch
+
+### Toggling a Checkbox
+
+```
+uno_app_element_peer_default_action(elementRef: "checkbox_handle")
+```
+
+### Verifying State
+
+After toggling, get a new visual tree snapshot and check the element's state properties.
+
+## Slider Interactions
+
+### Using Keyboard
+
+1. Focus the slider
+2. Use arrow keys:
+   ```
+   uno_app_key_press(virtualKey: "Right")  // Increase
+   uno_app_key_press(virtualKey: "Left")   // Decrease
+   ```
+
+### Using Page Keys
+
+For larger jumps:
+```
+uno_app_key_press(virtualKey: "PageUp")
+uno_app_key_press(virtualKey: "PageDown")
+```
+
+## Dialog Handling
+
+### Detecting a Dialog
+
+Get the visual tree and look for:
+- `ContentDialog` elements
+- Popup or flyout containers
+- Modal overlay elements
+
+### Dismissing Dialogs
+
+Use the dialog's button handles or:
+```
+uno_app_key_press(virtualKey: "Escape")  // Cancel/Close
+uno_app_key_press(virtualKey: "Enter")   // Accept/OK
+```
+
+## Scroll Interactions
+
+### Scrolling with Mouse Wheel
+
+Not directly supported; use keyboard alternatives:
+```
+uno_app_key_press(virtualKey: "PageDown")  // Scroll down
+uno_app_key_press(virtualKey: "PageUp")    // Scroll up
+uno_app_key_press(virtualKey: "Home")      // Scroll to top
+uno_app_key_press(virtualKey: "End")       // Scroll to bottom
+```
+
+### Scrolling to Element
+
+If an element is off-screen, focusing it may scroll it into view:
+```
+uno_app_element_peer_default_action(elementRef: "offscreen_element_handle")
+```
+
+## Context Menu Interactions
+
+### Opening Context Menu
+
+```
+uno_app_pointer_click(x: 200, y: 150, button: "right", clickCount: 1)
+```
+
+### Selecting Menu Item
+
+After opening, get the visual tree to find menu items and use default action.
+
+## Drag and Drop
+
+### Basic Drag Operation
+
+Drag operations typically require:
+1. Mouse down at source
+2. Move to destination
+3. Mouse up
+
+This pattern is complex and may require coordinate-based interaction with careful timing. Consider testing drag-and-drop logic through unit tests where possible.
+
+## Timing and Synchronization
+
+### Waiting for UI Updates
+
+After actions that trigger async operations or animations:
+1. Get a fresh visual tree snapshot
+2. Check for expected state changes
+3. Retry if needed with brief delays
+
+### Handling Loading States
+
+Look for loading indicators in the visual tree:
+- Progress rings/bars
+- Disabled states on interactive elements
+- Loading text or placeholders
+
+Wait until these are no longer present before continuing.
+
+## Error Recovery
+
+### Element Not Responding
+
+1. Try refreshing the visual tree
+2. Verify element is still visible and enabled
+3. Try alternative interaction method (keyboard vs mouse)
+4. Check if a dialog or overlay is blocking
+
+### Unexpected State
+
+1. Capture screenshot for debugging
+2. Get visual tree for analysis
+3. Consider restarting the app and test

--- a/skills/uno-testing-ui/references/VISUAL-TREE-GUIDE.md
+++ b/skills/uno-testing-ui/references/VISUAL-TREE-GUIDE.md
@@ -1,0 +1,255 @@
+# Visual Tree Inspection Guide
+
+This guide explains how to effectively use the `uno_app_visualtree_snapshot` tool to inspect and interact with UI elements in Uno Platform applications.
+
+## Understanding the Visual Tree
+
+The visual tree represents the hierarchical structure of all UI elements currently rendered in the application. Each element in the tree includes:
+
+- **Type**: The element class (Button, TextBox, Grid, etc.)
+- **Name**: The `x:Name` if defined in XAML
+- **Handle**: A unique reference for interaction tools
+- **Properties**: Relevant properties like Content, Text, IsEnabled
+- **Automation Properties**: AutomationId, Name, HelpText
+- **Bounds**: Position and size (when requested)
+
+## Tool Parameters
+
+### justMyCode (default: true)
+
+When `true`, filters the tree to show only elements defined in your application code:
+- Removes internal framework elements
+- Hides template internals
+- Shows cleaner, more navigable output
+
+Set to `false` when you need to:
+- Debug template issues
+- Interact with framework-level elements
+- Understand complete element composition
+
+### includeBounds (default: false)
+
+When `true`, includes element position and size:
+- X, Y coordinates (absolute physical pixels)
+- Width and Height
+- Useful for coordinate-based interactions
+
+Set to `true` when:
+- Using `uno_app_pointer_click`
+- Debugging layout issues
+- Calculating click positions
+
+### includeHidden (default: false)
+
+When `true`, includes hidden/collapsed elements:
+- Elements with `Visibility.Collapsed`
+- Elements with `Opacity = 0`
+- Elements outside the visible viewport
+
+Set to `true` when:
+- Looking for elements that may appear later
+- Debugging visibility binding issues
+- Testing conditional UI logic
+
+## Reading the XML Output
+
+### Basic Element Structure
+
+```xml
+<StackPanel handle="sp_001" Orientation="Vertical">
+  <TextBlock handle="tb_001" Text="Welcome" />
+  <Button handle="btn_001" x:Name="LoginButton" Content="Log In" IsEnabled="true">
+    <Button.AutomationProperties>
+      <AutomationId>LoginBtn</AutomationId>
+      <Name>Log In Button</Name>
+    </Button.AutomationProperties>
+  </Button>
+</StackPanel>
+```
+
+### Key Attributes to Look For
+
+| Attribute | Purpose |
+|-----------|---------|
+| `handle` | Required for interaction tools |
+| `x:Name` | Developer-assigned name |
+| `AutomationId` | Test automation identifier |
+| `Content` | Button/ContentControl content |
+| `Text` | TextBlock/TextBox text |
+| `IsEnabled` | Whether element accepts interaction |
+| `IsChecked` | Checkbox/Toggle state |
+
+### With Bounds Included
+
+```xml
+<Button handle="btn_001" 
+        x:Name="SubmitButton" 
+        Content="Submit"
+        Bounds="100,200,150,40">
+  <!-- X=100, Y=200, Width=150, Height=40 -->
+</Button>
+```
+
+The center point for clicking would be:
+- X: 100 + (150/2) = 175
+- Y: 200 + (40/2) = 220
+
+## Common Element Types
+
+### Layout Containers
+
+- `Grid` - Row/column-based layout
+- `StackPanel` - Linear stacking (horizontal or vertical)
+- `Border` - Single-child with border/background
+- `ScrollViewer` - Scrollable content area
+
+### Input Elements
+
+- `Button` - Clickable button (use default action)
+- `TextBox` - Text input (focus, then type)
+- `PasswordBox` - Secure text input
+- `ComboBox` - Dropdown selection
+- `CheckBox` - Boolean toggle
+- `RadioButton` - Exclusive selection
+- `Slider` - Range value selection
+- `ToggleSwitch` - On/off toggle
+
+### Display Elements
+
+- `TextBlock` - Read-only text
+- `Image` - Image display
+- `ProgressRing` / `ProgressBar` - Loading indicators
+- `ListView` / `ItemsRepeater` - List of items
+
+### Navigation Elements
+
+- `NavigationView` - Side navigation
+- `TabView` - Tab-based navigation
+- `Frame` - Page container
+
+## Finding Elements Strategies
+
+### By Name
+
+Look for `x:Name` attribute:
+```xml
+<Button x:Name="SaveButton" handle="btn_save" ... />
+```
+
+### By AutomationId
+
+Best practice for test automation:
+```xml
+<Button handle="btn_001">
+  <Button.AutomationProperties>
+    <AutomationId>SaveBtn</AutomationId>
+  </Button.AutomationProperties>
+</Button>
+```
+
+### By Content/Text
+
+For buttons and text elements:
+```xml
+<Button handle="btn_001" Content="Submit" />
+<TextBlock handle="tb_001" Text="Welcome, User" />
+```
+
+### By Type and Position
+
+When elements lack unique identifiers:
+1. Find parent container
+2. Look for elements by type in order
+3. Use the nth occurrence
+
+### By Hierarchy
+
+Navigate the tree structure:
+```xml
+<Page>
+  <Grid x:Name="RootGrid">
+    <StackPanel x:Name="LoginPanel">
+      <Button x:Name="LoginButton" handle="target_handle" />
+    </StackPanel>
+  </Grid>
+</Page>
+```
+
+## Handling Dynamic Content
+
+### Lists and Collections
+
+ListView items have handles but may be recycled:
+```xml
+<ListView handle="list_001">
+  <ListViewItem handle="item_001" Content="First Item" />
+  <ListViewItem handle="item_002" Content="Second Item" />
+  <ListViewItem handle="item_003" Content="Third Item" />
+</ListView>
+```
+
+**Important:** Item handles may change when scrolling. Always get a fresh snapshot before interacting.
+
+### Conditional UI
+
+Elements may appear/disappear based on state:
+- Use `includeHidden: true` to see collapsed elements
+- Refresh tree after state changes
+- Wait for async operations to complete
+
+### Loading Content
+
+During loading, you may see:
+- Empty containers
+- Placeholder elements
+- Progress indicators
+
+Wait for loading to complete before proceeding.
+
+## Debugging Tips
+
+### Element Not Found
+
+1. Set `justMyCode: false` to see all elements
+2. Set `includeHidden: true` to see collapsed elements
+3. Check if element is inside a different page/view
+4. Verify XAML defines the expected element
+
+### Wrong Element Focused
+
+1. Get visual tree to verify focus state
+2. Use Tab navigation to move focus
+3. Try clicking the element first
+
+### Stale Handles
+
+After significant UI changes:
+1. Always refresh the visual tree
+2. Use new handles from fresh snapshot
+3. Don't cache handles between operations
+
+## Performance Considerations
+
+### Large Trees
+
+For complex UIs, the tree can be large:
+- Use `justMyCode: true` to reduce size
+- Navigate to specific page/view first
+- Look for parent containers to narrow scope
+
+### Frequent Updates
+
+Don't call visual tree snapshot excessively:
+- Get snapshot before a series of related operations
+- Refresh only when state changes significantly
+- Cache element locations for multiple clicks in same area
+
+## Best Practices Summary
+
+1. **Always set justMyCode: true** unless debugging framework issues
+2. **Use AutomationId** for reliable element identification
+3. **Refresh tree after UI changes** before interacting
+4. **Get bounds only when needed** for coordinate clicks
+5. **Prefer handles over coordinates** for reliability
+6. **Check IsEnabled** before attempting interaction
+7. **Handle dynamic content** with fresh snapshots

--- a/skills/uno-themes-material/SKILL.md
+++ b/skills/uno-themes-material/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: uno-themes-material
+description: "Comprehensive reference for the Uno Material theme — Material Design 3 styling for Uno Platform apps. Covers installation, the MD3 color palette and brush system, semantic typography, control styles (buttons, FAB, TextBox), control extensions (icons, elevation), lightweight styling, color/font customization, and version migration."
+when_to_use: "Use whenever working with Uno Material theming: setting up MaterialTheme or MaterialToolkitTheme, applying button / FAB / TextBox / typography styles, picking color palette keys, customizing colors or fonts via Theme Builder, applying lightweight styling overrides, adding control extensions (icons, elevation), or migrating between Material versions."
+metadata:
+  author: uno-platform
+  version: "1.0"
+  framework: uno-platform
+  category: themes
+---
+
+# Uno Material — Agent Skill
+
+Consolidated reference for the Uno Material theme. For any deep dive (full key tables, code samples, version-specific gotchas), fetch the authoritative docs via the steps below; the inline tables here cover the most-asked-for facts for fast lookup.
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Pick the relevant topic and search the docs
+
+| Topic | Search query |
+|---|---|
+| Installation / `MaterialTheme` / `UnoFeatures` | `uno_platform_docs_search("Uno Material installation MaterialTheme UnoFeatures")` |
+| Control styles (Button / TextBox / FAB / etc.) | `uno_platform_docs_search("Uno Material controls styles")` |
+| Color palette + brushes (MD3) | `uno_platform_docs_search("Uno Material colors brushes MD3 palette")` |
+| Typography / type scale | `uno_platform_docs_search("Uno Material typography type scale")` |
+| Lightweight styling (per-control overrides) | `uno_platform_docs_search("Uno Material lightweight styling resource keys")` |
+| Color customization / Theme Builder | `uno_platform_docs_search("Uno Material color customization Theme Builder DSP")` |
+| Font customization | `uno_platform_docs_search("Uno Material font customization font family override")` |
+| Control extensions (icons, elevation) | `uno_platform_docs_search("Uno Material control extensions icons elevation")` |
+| C# Markup with Material | `uno_platform_docs_search("Uno.Themes.WinUI.Markup C# Markup Material")` |
+| Version migration | `uno_platform_docs_search("Uno Material migration v1 v2 v3")` |
+
+### Step 2: Fetch the canonical pages
+
+- **Material Getting Started**: `external/uno.themes/doc/material-getting-started.md`
+- **Material Toolkit Getting Started**: `external/uno.toolkit.ui/doc/material-getting-started.md` (use `MaterialToolkitTheme` for Toolkit+Material)
+- **Material Controls Styles**: `external/uno.themes/doc/material-controls-styles.md`
+- **Lightweight Styling**: `external/uno.themes/doc/lightweight-styling.md`
+- **Material Migration**: `external/uno.themes/doc/material-migration.md`
+
+```
+uno_platform_docs_fetch(sourcePath="…")  # the sourcePath field from a search result above; never a URL/.html
+```
+
+## Critical Rules
+
+- **Brushes use `{ThemeResource}`, NOT `{StaticResource}`** — so the bound color follows the active theme (Light / Dark) at runtime. `<TextBlock Foreground="{ThemeResource PrimaryBrush}" />`.
+- **Styles use `{StaticResource}`** — control styles don't change with the theme; their internal bindings already use ThemeResource for brushes.
+- **Use `MaterialToolkitTheme` or `MaterialTheme`, not both** — when using both Toolkit + Material, `MaterialToolkitTheme` replaces `MaterialTheme + ToolkitResources`. Mixing them double-loads resources.
+
+## Installation (quick reference)
+
+In `.csproj`:
+```xml
+<UnoFeatures>Material</UnoFeatures>             <!-- or Material;Toolkit -->
+```
+
+In `App.xaml`:
+```xml
+<ResourceDictionary.MergedDictionaries>
+    <MaterialTheme xmlns="using:Uno.Material" />
+</ResourceDictionary.MergedDictionaries>
+```
+
+Use `<MaterialToolkitTheme xmlns="using:Uno.Toolkit.Material" />` if also using Uno Toolkit.
+
+## Control Style Keys (quick reference)
+
+### Button
+
+| Style key | Use for |
+|---|---|
+| `FilledButtonStyle` | **Default**. Primary actions ("Save", "Submit") |
+| `ElevatedButtonStyle` | Primary action with elevation/shadow |
+| `FilledTonalButtonStyle` | Secondary action; softer than Filled |
+| `OutlinedButtonStyle` | Secondary action with border |
+| `TextButtonStyle` | Tertiary / low-emphasis action |
+| `IconButtonStyle` | Icon-only action (pair with `Icons.Icon` attached property) |
+
+### FAB (FloatingActionButton; applied to `Button`)
+
+| Style key family | Sizes |
+|---|---|
+| `FabStyle` / `SmallFabStyle` / `LargeFabStyle` | Primary FAB |
+| `SecondaryFabStyle` / `SecondarySmallFabStyle` / `SecondaryLargeFabStyle` | Secondary color |
+| `TertiaryFabStyle` / `TertiarySmallFabStyle` / `TertiaryLargeFabStyle` | Tertiary color |
+| `SurfaceFabStyle` / `SurfaceSmallFabStyle` / `SurfaceLargeFabStyle` | Surface color |
+
+### TextBox / PasswordBox
+
+| Style key | Notes |
+|---|---|
+| `FilledTextBoxStyle` | **Material default** for TextBox |
+| `OutlinedTextBoxStyle` | Outlined variant |
+| `FilledPasswordBoxStyle` | **Material default** for PasswordBox |
+| `OutlinedPasswordBoxStyle` | Outlined variant |
+
+## Color Palette Keys (Layer 1)
+
+Material follows the MD3 role system. 32 color keys with Light/Dark variants. Most-used role families:
+
+- **Primary**: `PrimaryColor`, `OnPrimaryColor`, `PrimaryContainerColor`, `OnPrimaryContainerColor`, `PrimaryInverseColor`
+- **Secondary**: `SecondaryColor`, `OnSecondaryColor`, `SecondaryContainerColor`, `OnSecondaryContainerColor`
+- **Tertiary**: `TertiaryColor`, `OnTertiaryColor`, `TertiaryContainerColor`, `OnTertiaryContainerColor`
+- **Error**: `ErrorColor`, `OnErrorColor`, `ErrorContainerColor`, `OnErrorContainerColor`
+- **Surface**: `SurfaceColor`, `OnSurfaceColor`, `SurfaceVariantColor`, `OnSurfaceVariantColor`, `SurfaceInverseColor`, `OnSurfaceInverseColor`, `SurfaceTintColor`
+- **Background / Outline / Shadow**: `BackgroundColor`, `OnBackgroundColor`, `OutlineColor`, `OutlineVariantColor`, `ShadowColor`
+
+**Pairing rule**: every background role has a designated foreground role. `PrimaryBrush` ↔ `OnPrimaryBrush`. `ErrorContainerBrush` ↔ `OnErrorContainerBrush`. Don't mix unpaired colors. (See `uno-themes-semantic-colors-brushes` for the shared semantic surface common to Material + Simple.)
+
+## Brush System (Layer 2)
+
+Each color key generates ~9 brush variants with opacity tokens. Pattern: `{ColorRole}{StateVariant}Brush`.
+
+| Suffix | Opacity | Purpose |
+|---|---|---|
+| *(none)* | 1.0 | Rest state |
+| `Hover` | 0.08 | Pointer hover layer |
+| `Focused` | 0.12 | Keyboard focus layer |
+| `Pressed` | 0.12 | Active press layer |
+| `Dragged` | 0.16 | Drag operation layer |
+| `Selected` | 0.08 | Selected item layer |
+| `Medium` | 0.64 | Medium-emphasis text/icons |
+| `Low` | 0.32 | Low-emphasis text, placeholders |
+| `Disabled` | 0.12 | Disabled state |
+
+Total: ~288 brushes generated from the palette + opacity tokens.
+
+## Typography (Layer)
+
+M3 type scale, used as `TextBlock` styles. **Never theme-prefix typography keys** — write `DisplayLarge`, not `MaterialDisplayLarge`.
+
+| Family | Keys |
+|---|---|
+| Display | `DisplayLarge`, `DisplayMedium`, `DisplaySmall` |
+| Headline | `HeadlineLarge`, `HeadlineMedium`, `HeadlineSmall` |
+| Title | `TitleLarge`, `TitleMedium`, `TitleSmall` |
+| Body | `BodyLarge`, `BodyMedium`, `BodySmall` |
+| Label | `LabelLarge`, `LabelMedium`, `LabelSmall`, `LabelExtraSmall` |
+| Caption | `CaptionLarge`, `CaptionMedium`, `CaptionSmall` |
+
+Each style exposes `{StyleKey}FontFamily`, `FontSize`, `FontWeight` resource keys for lightweight styling overrides.
+
+## Control Extensions
+
+Material ships attached properties for icon, elevation, and toggle-content patterns (namespace `using:Uno.Material.Controls`):
+
+- **`Icons.Icon`** — adds an icon to a `Button` (esp. `IconButtonStyle`).
+- **Elevation extensions** — apply MD3 elevation shadows; layered with `ShadowContainer` for richer effects.
+- **Alternate content** — display different content based on `ToggleButton.IsChecked`.
+
+## Customization
+
+Three escalating scopes:
+
+1. **Palette override (full cascade)** — override `*Color` keys via `ColorOverrideSource` / `ColorOverrideDictionary` on `MaterialTheme`. All ~288 brushes and controls update automatically. Generate the palette XAML via **Material Theme Builder** (DSP format).
+2. **Specific brush override (targeted)** — drop a `<SolidColorBrush x:Key="FilledButtonBackground" Color="..." />` into App.xaml or scoped resources.
+3. **Per-instance override (scoped)** — wrap the override in the control's `Resources` block.
+
+Font override: set `FontOverrideSource` / `FontOverrideDictionary` on `MaterialTheme`, or override individual `*FontFamily` keys.
+
+## C# Markup
+
+Use `Uno.Themes.WinUI.Markup` for fluent C# styling — `.MaterialFilledButtonStyle()`, `.MaterialOutlinedTextBoxStyle()`, etc. Resource keys exposed as constants under `MaterialThemeResources`.
+
+```csharp
+new Button().Content("Save").MaterialFilledButtonStyle()
+```
+
+## Migration
+
+Between major versions, resource keys, converters, and style names can change. Fetch the migration page on upgrade:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.themes/doc/material-migration.md")
+```
+
+Key checks: renamed resource keys, removed converters, NuGet package renames, `UnoFeatures` flag changes.
+
+## Related Skills
+
+- [[uno-themes-semantic-colors-brushes]] — Shared semantic design language (style keys + typography + colors that work across Material AND Simple themes). Read this first if styling needs to be portable between themes.
+- [[uno-themes-simple]] — Simple theme specifics. Use when targeting Simple (designer/wireframe look) or its theme-specific styles (danger buttons, size variants, utility brushes, PersonPicture, etc.).
+- [[uno-toolkit-material-theme]] — `MaterialToolkitTheme` setup for Toolkit + Material.

--- a/skills/uno-themes-semantic-colors-brushes/SKILL.md
+++ b/skills/uno-themes-semantic-colors-brushes/SKILL.md
@@ -1,0 +1,379 @@
+---
+name: uno-themes-semantic-colors-brushes
+description: "Comprehensive reference for the Uno Themes Semantic Design Language. Covers semantic control styles, typography, 33 color palette keys, ~288 generated brushes, opacity/state system, color pairing rules, and theme customization."
+when_to_use: "Use when styling apps with Uno Themes, choosing correct semantic style keys, using typography resources, selecting color roles, customizing the color palette, or understanding the relationship between colors, brushes, styles, and interactive states."
+metadata:
+  author: custom
+  version: "2.7"
+  framework: uno-platform
+  category: themes
+---
+
+# Uno Themes Semantic Design Language
+
+This skill is the definitive reference for the **Semantic Design Language** in Uno Themes. The semantic system is **design-theme agnostic** -- the same style keys, typography keys, color keys, and brush keys are shared across every design-theme implementation. Each implementation supplies its own concrete values and may not implement every key, but the semantic names are shared. Consult the design-theme-specific skills for concrete styles, palettes, and theme-only extensions.
+
+---
+
+## Part 1: Semantic Control Styles
+
+### How It Works
+
+Each design-theme's `_Resources.xaml` defines `<StaticResource>` aliases that map the shared semantic key to the theme's concrete style (e.g. `FilledButtonStyle` -> `{ThemePrefix}FilledButtonStyle`).
+
+Use semantic keys in XAML for portable, theme-agnostic styling:
+
+```xml
+<Button Style="{StaticResource FilledButtonStyle}" Content="Save" />
+```
+
+### Complete Style Key Reference
+
+| Semantic Key | Control | Default | Notes |
+|---|---|---|---|
+| `FilledButtonStyle` | `Button` | Yes | |
+| `ElevatedButtonStyle` | `Button` | | Not implemented by every design-theme |
+| `FilledTonalButtonStyle` | `Button` | | |
+| `OutlinedButtonStyle` | `Button` | | Not implemented by every design-theme |
+| `TextButtonStyle` | `Button` | | |
+| `IconButtonStyle` | `Button` | | |
+| `TextToggleButtonStyle` | `ToggleButton` | | |
+| `IconToggleButtonStyle` | `ToggleButton` | Yes | Default implicit for ToggleButton |
+| `FilledTextBoxStyle` | `TextBox` | | |
+| `OutlinedTextBoxStyle` | `TextBox` | | Implicit default in some design-themes |
+| `FilledPasswordBoxStyle` | `PasswordBox` | | |
+| `OutlinedPasswordBoxStyle` | `PasswordBox` | | Implicit default in some design-themes |
+| `ComboBoxStyle` | `ComboBox` | Yes | |
+| `ComboBoxItemStyle` | `ComboBoxItem` | | |
+| `CheckBoxStyle` | `CheckBox` | Yes | |
+| `RadioButtonStyle` | `RadioButton` | Yes | |
+| `ToggleSwitchStyle` | `ToggleSwitch` | Yes | |
+| `SliderStyle` | `Slider` | Yes | |
+| `HyperlinkButtonStyle` | `HyperlinkButton` | Yes | |
+| `SecondaryHyperlinkButtonStyle` | `HyperlinkButton` | | |
+| `ListViewStyle` | `ListView` | Yes | |
+| `ListViewItemStyle` | `ListViewItem` | Yes | |
+| `ContentDialogStyle` | `ContentDialog` | Yes | |
+| `CommandBarStyle` | `CommandBar` | Yes | Not implemented by every design-theme |
+| `AppBarButtonStyle` | `AppBarButton` | Yes | |
+| `NavigationViewStyle` | `NavigationView` | Yes | |
+| `NavigationViewItemStyle` | `NavigationViewItem` | Yes | |
+| `CalendarViewStyle` | `CalendarView` | Yes | |
+| `CalendarDatePickerStyle` | `CalendarDatePicker` | Yes | |
+| `DatePickerStyle` | `DatePicker` | Yes | |
+| `DatePickerFlyoutPresenterStyle` | `DatePickerFlyoutPresenter` | Yes | Not implemented by every design-theme |
+| `MediaTransportControlsStyle` | `MediaTransportControls` | Yes | Not implemented by every design-theme |
+| `ProgressBarStyle` | `ProgressBar` | Yes | |
+| `ProgressRingStyle` | `ProgressRing` | Yes | |
+| `PipsPagerStyle` | `PipsPager` | Yes | |
+| `RatingControlStyle` | `RatingControl` | Yes | |
+| `FlyoutPresenterStyle` | `FlyoutPresenter` | Yes | |
+| `MenuFlyoutPresenterStyle` | `MenuFlyoutPresenter` | Yes | |
+| `MenuFlyoutItemStyle` | `MenuFlyoutItem` | Yes | |
+| `MenuFlyoutSeparatorStyle` | `MenuFlyoutSeparator` | Yes | |
+| `MenuFlyoutSubItemStyle` | `MenuFlyoutSubItem` | Yes | |
+| `ToggleMenuFlyoutItemStyle` | `ToggleMenuFlyoutItem` | Yes | |
+| `RadioMenuFlyoutItemStyle` | `RadioMenuFlyoutItem` | Yes | |
+
+#### FAB Styles
+
+| Semantic Key | Control | Notes |
+|---|---|---|
+| `FabStyle` | `Button` | Primary FAB |
+| `SmallFabStyle` | `Button` | |
+| `LargeFabStyle` | `Button` | |
+| `SecondaryFabStyle` | `Button` | |
+| `SecondarySmallFabStyle` | `Button` | |
+| `SecondaryLargeFabStyle` | `Button` | |
+| `TertiaryFabStyle` | `Button` | |
+| `TertiarySmallFabStyle` | `Button` | |
+| `TertiaryLargeFabStyle` | `Button` | |
+| `SurfaceFabStyle` | `Button` | |
+| `SurfaceSmallFabStyle` | `Button` | |
+| `SurfaceLargeFabStyle` | `Button` | |
+
+> **Note:** Individual design-themes may also expose additional theme-prefixed styles (e.g. danger variants, size variants, controls without a cross-theme equivalent) that are **not** part of the shared semantic surface. See the design-theme-specific skills for those.
+
+---
+
+## Part 2: Semantic Typography
+
+Each design-theme provides semantic typography keys based on the M3 type scale. Concrete font families, sizes, and weights are supplied by the active design-theme's `Typography.xaml`; the semantic key names are shared.
+
+### Typography Style Keys
+
+Use these as TextBlock styles:
+
+```xml
+<TextBlock Style="{StaticResource DisplayLarge}" Text="Hero" />
+<TextBlock Style="{StaticResource BodyMedium}" Text="Body text" />
+```
+
+### Font Resource Keys
+
+Each typography style exposes individual font properties for lightweight styling:
+
+| Style Key | Font Resource Keys |
+|---|---|
+| `DisplayLarge` | `DisplayLargeFontFamily`, `DisplayLargeFontSize`, `DisplayLargeFontWeight`, `DisplayLargeCharacterSpacing` |
+| `DisplayMedium` | `DisplayMediumFontFamily`, `DisplayMediumFontSize`, `DisplayMediumFontWeight` |
+| `DisplaySmall` | `DisplaySmallFontFamily`, `DisplaySmallFontSize`, `DisplaySmallFontWeight` |
+| `HeadlineLarge` | `HeadlineLargeFontFamily`, `HeadlineLargeFontSize`, `HeadlineLargeFontWeight` |
+| `HeadlineMedium` | `HeadlineMediumFontFamily`, `HeadlineMediumFontSize`, `HeadlineMediumFontWeight` |
+| `HeadlineSmall` | `HeadlineSmallFontFamily`, `HeadlineSmallFontSize`, `HeadlineSmallFontWeight` |
+| `TitleLarge` | `TitleLargeFontFamily`, `TitleLargeFontSize`, `TitleLargeFontWeight` |
+| `TitleMedium` | `TitleMediumFontFamily`, `TitleMediumFontSize`, `TitleMediumFontWeight` |
+| `TitleSmall` | `TitleSmallFontFamily`, `TitleSmallFontSize`, `TitleSmallFontWeight` |
+| `BodyLarge` | `BodyLargeFontFamily`, `BodyLargeFontSize`, `BodyLargeFontWeight` |
+| `BodyMedium` | `BodyMediumFontFamily`, `BodyMediumFontSize`, `BodyMediumFontWeight` |
+| `BodySmall` | `BodySmallFontFamily`, `BodySmallFontSize`, `BodySmallFontWeight` |
+| `LabelLarge` | `LabelLargeFontFamily`, `LabelLargeFontSize`, `LabelLargeFontWeight` |
+| `LabelMedium` | `LabelMediumFontFamily`, `LabelMediumFontSize`, `LabelMediumFontWeight` |
+| `LabelSmall` | `LabelSmallFontFamily`, `LabelSmallFontSize`, `LabelSmallFontWeight` |
+| `LabelExtraSmall` | `LabelExtraSmallFontFamily`, `LabelExtraSmallFontSize`, `LabelExtraSmallFontWeight` |
+| `CaptionLarge` | `CaptionLargeFontFamily`, `CaptionLargeFontSize`, `CaptionLargeFontWeight` |
+| `CaptionMedium` | `CaptionMediumFontFamily`, `CaptionMediumFontSize`, `CaptionMediumFontWeight` |
+| `CaptionSmall` | `CaptionSmallFontFamily`, `CaptionSmallFontSize`, `CaptionSmallFontWeight` |
+
+### Typography Decision Guide
+
+| Purpose | Style Key |
+|---------|-----------|
+| Hero / splash text | `DisplayLarge` |
+| Page title | `DisplayMedium` or `HeadlineLarge` |
+| Section heading | `HeadlineMedium` or `HeadlineSmall` |
+| Card / dialog title | `TitleLarge` or `TitleMedium` |
+| Button / tab label | `LabelLarge` |
+| Primary body text | `BodyLarge` |
+| Secondary body text | `BodyMedium` |
+| Caption / helper text | `CaptionMedium` or `BodySmall` |
+| Badge / small label | `LabelSmall` or `LabelExtraSmall` |
+
+---
+
+## Part 3: Semantic Colors & Brushes
+
+### Architecture: Three Layers
+
+```
+Layer 1: Color Palette (SharedColorPalette.xaml)
+    33 Color resources with Light/Dark theme variants
+           |
+           v
+Layer 2: Semantic Brushes (SharedColors.xaml)
+    ~288 SolidColorBrush resources generated from palette + opacity tokens
+           |
+           v
+Layer 3: Control Lightweight Styling Keys
+    Per-control resource keys that reference semantic brushes
+    (e.g., FilledButtonBackground -> PrimaryBrush)
+```
+
+- **Override Layer 1** to rebrand the entire app (all brushes cascade automatically).
+- **Override Layer 2** to change a specific brush without affecting the palette.
+- **Override Layer 3** to change a single control's appearance without affecting the brush system.
+
+### The Color Palette (Layer 1)
+
+Defined in `SharedColorPalette.xaml`, these 33 `Color` resources are the foundation.
+
+#### Primary -- Brand Identity & Key Actions
+
+| Color Key | Role | When to Use |
+|-----------|------|-------------|
+| `PrimaryColor` | Hero brand color | Filled button backgrounds, active toggle states, FAB backgrounds |
+| `OnPrimaryColor` | Content on Primary | Text and icons on Primary surfaces |
+| `PrimaryContainerColor` | Softer primary fill | Tonal button backgrounds, selected navigation items, chips |
+| `OnPrimaryContainerColor` | Content on Primary Container | Text and icons on PrimaryContainer surfaces |
+| `PrimaryInverseColor` | Inverted primary accent | Links on inverse surfaces (e.g., dark snackbar) |
+
+#### Legacy Primary Variants
+
+| Color Key | Role |
+|-----------|------|
+| `PrimaryVariantDarkColor` | Darker primary shade (M2 compat) |
+| `PrimaryVariantLightColor` | Lighter primary shade (M2 compat) |
+
+#### Secondary -- Supporting Accents
+
+| Color Key | Role | When to Use |
+|-----------|------|-------------|
+| `SecondaryColor` | Supporting accent | Filter chips, secondary action buttons |
+| `OnSecondaryColor` | Content on Secondary | Text and icons on Secondary surfaces |
+| `SecondaryContainerColor` | Softer secondary fill | NavigationView selected item, info banners |
+| `OnSecondaryContainerColor` | Content on Secondary Container | Text and icons on SecondaryContainer |
+
+#### Legacy Secondary Variants
+
+| Color Key | Role |
+|-----------|------|
+| `SecondaryVariantDarkColor` | Darker secondary shade (M2 compat) |
+| `SecondaryVariantLightColor` | Lighter secondary shade (M2 compat) |
+
+#### Tertiary -- Contrast & Balance
+
+| Color Key | Role | When to Use |
+|-----------|------|-------------|
+| `TertiaryColor` | Third accent | Tertiary FABs, accents distinct from Primary and Secondary |
+| `OnTertiaryColor` | Content on Tertiary | Text and icons on Tertiary surfaces |
+| `TertiaryContainerColor` | Softer tertiary fill | Complementary cards, input fields |
+| `OnTertiaryContainerColor` | Content on Tertiary Container | Text and icons on TertiaryContainer |
+
+#### Error -- Validation & Destructive Actions
+
+| Color Key | Role | When to Use |
+|-----------|------|-------------|
+| `ErrorColor` | Danger/error accent | Error text, destructive button backgrounds |
+| `OnErrorColor` | Content on Error | Text and icons on Error surfaces |
+| `ErrorContainerColor` | Softer error fill | Error banners, validation backgrounds |
+| `OnErrorContainerColor` | Content on Error Container | Text and icons on ErrorContainer |
+
+#### Surface -- Component Backgrounds
+
+| Color Key | Role | When to Use |
+|-----------|------|-------------|
+| `SurfaceColor` | Default component background | Cards, dialogs, sheets, menus |
+| `OnSurfaceColor` | Primary text/icons | Highest-emphasis content: titles, body text |
+| `SurfaceVariantColor` | Differentiated surface | ToggleSwitch tracks, Slider tracks, subtle section backgrounds |
+| `OnSurfaceVariantColor` | Secondary text/icons | Helper text, captions, lower-emphasis icons |
+| `SurfaceInverseColor` | Inverted surface | Snackbars, tooltips |
+| `OnSurfaceInverseColor` | Content on inverse surface | Text on snackbars and tooltips |
+| `SurfaceTintColor` | Elevation tint | Tint overlay for elevated surfaces |
+
+#### Background, Outline, Shadow
+
+| Color Key | Role |
+|-----------|------|
+| `BackgroundColor` | Root page background |
+| `OnBackgroundColor` | Content on background |
+| `OutlineColor` | Interactive boundaries (button borders, input outlines) |
+| `OutlineVariantColor` | Decorative boundaries (card edges, dividers) |
+| `ShadowColor` | Drop shadow color |
+
+### The Brush System (Layer 2)
+
+Every Color key generates **9 SolidColorBrush variants** at different opacity levels.
+
+#### Brush Naming Pattern: `{ColorRole}{StateVariant}Brush`
+
+| Suffix | Opacity | Purpose |
+|--------|---------|---------|
+| *(none)* | 1.0 | Default/rest state |
+| `Hover` | 0.08 | Pointer hover state layer |
+| `Focused` | 0.12 | Keyboard focus state layer |
+| `Pressed` | 0.12 | Active press state layer |
+| `Dragged` | 0.16 | Drag operation state layer |
+| `Selected` | 0.08 | Selected item state layer |
+| `Medium` | 0.64 | Medium-emphasis text/icons |
+| `Low` | 0.32 | Low-emphasis text, placeholders |
+| `Disabled` | 0.12 | Disabled state backgrounds |
+
+**Total: ~288 semantic brushes** across Primary (63), Secondary (54), Tertiary (36), Error (36), Surface (63), Background (18), Outline (18).
+
+### Color Pairing Rules (CRITICAL)
+
+**NEVER mix unpaired colors.** Every background role has a designated "On" foreground role.
+
+| If Background Is... | Then Foreground MUST Be... |
+|----------------------|---------------------------|
+| `PrimaryBrush` | `OnPrimaryBrush` |
+| `PrimaryContainerBrush` | `OnPrimaryContainerBrush` |
+| `SecondaryBrush` | `OnSecondaryBrush` |
+| `SecondaryContainerBrush` | `OnSecondaryContainerBrush` |
+| `TertiaryBrush` | `OnTertiaryBrush` |
+| `TertiaryContainerBrush` | `OnTertiaryContainerBrush` |
+| `ErrorBrush` | `OnErrorBrush` |
+| `ErrorContainerBrush` | `OnErrorContainerBrush` |
+| `SurfaceBrush` | `OnSurfaceBrush` or `OnSurfaceVariantBrush` |
+| `SurfaceVariantBrush` | `OnSurfaceVariantBrush` |
+| `BackgroundBrush` | `OnBackgroundBrush` |
+| `SurfaceInverseBrush` | `OnSurfaceInverseBrush` |
+
+### Text Emphasis on Surfaces
+
+| Emphasis | Brush | Use For |
+|----------|-------|---------|
+| High | `OnSurfaceBrush` | Titles, headings, primary labels |
+| Medium | `OnSurfaceVariantBrush` | Body text, secondary labels, captions |
+| Low / Disabled | `OnSurfaceLowBrush` | Disabled text, placeholder text |
+
+---
+
+## Part 4: Customization
+
+### Method 1: Override Color Palette (Full Cascade)
+
+Override `*Color` keys in a ResourceDictionary referenced by your theme. All ~288 brushes and controls update automatically.
+
+**Always provide both** `Light` and `Default` (Dark) theme values.
+
+### Method 2: Override Specific Brushes (Targeted)
+
+```xml
+<SolidColorBrush x:Key="FilledButtonBackground" Color="#006D3B" />
+```
+
+### Method 3: Override Per-Control Instance (Scoped)
+
+```xml
+<Button Style="{StaticResource FilledButtonStyle}">
+    <Button.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light">
+                    <SolidColorBrush x:Key="FilledButtonBackground" Color="#006D3B" />
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+        </ResourceDictionary>
+    </Button.Resources>
+</Button>
+```
+
+### Customization Precedence (Highest to Lowest)
+
+1. **Control.Resources** -- per-instance
+2. **Page.Resources** -- page-scoped
+3. **App-level overrides** -- app-wide
+4. **Theme defaults** -- active design-theme
+5. **SharedColorPalette / SharedColors / SharedTypography** -- foundation
+
+---
+
+## Decision Guides
+
+### Which Color Role?
+
+| Scenario | Background | Foreground |
+|----------|------------|------------|
+| Primary CTA ("Submit") | `PrimaryBrush` | `OnPrimaryBrush` |
+| Tonal action | `SecondaryContainerBrush` | `OnSecondaryContainerBrush` |
+| Outlined button border | `OutlineBrush` | `PrimaryBrush` |
+| Text-only action | Transparent | `PrimaryBrush` |
+| Destructive ("Delete") | `ErrorBrush` | `OnErrorBrush` |
+| Card / Dialog | `SurfaceBrush` | `OnSurfaceBrush` |
+| Error banner | `ErrorContainerBrush` | `OnErrorContainerBrush` |
+| Snackbar / Tooltip | `SurfaceInverseBrush` | `OnSurfaceInverseBrush` |
+
+### Which Button Style?
+
+| Scenario | Style Key |
+|----------|-----------|
+| Primary action | `FilledButtonStyle` |
+| Secondary action | `FilledTonalButtonStyle` or `OutlinedButtonStyle` |
+| Tertiary / low emphasis | `TextButtonStyle` |
+| Icon-only action | `IconButtonStyle` |
+
+### XAML Best Practices
+
+- Always use `ThemeResource` (not `StaticResource`) for brushes so they respond to theme changes.
+- Always use `StaticResource` for styles (styles don't change with theme).
+- Use semantic keys, not theme-prefixed keys, for portable XAML.
+
+```xml
+<!-- Correct -->
+<Button Style="{StaticResource FilledButtonStyle}"
+        Content="Save" />
+
+<!-- Avoid theme-prefixed keys in portable code -->
+<!-- <Button Style="{StaticResource {ThemePrefix}FilledButtonStyle}" /> -->
+```

--- a/skills/uno-themes-simple/SKILL.md
+++ b/skills/uno-themes-simple/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: uno-themes-simple
+description: "Comprehensive reference for the Uno Simple theme — designer/wireframe-style theming for Uno Platform apps. Covers SimpleTheme configuration (color/font overrides, default size), Simple-specific style keys (danger buttons, size variants, error inputs, PersonPicture variants), controls without Material equivalent (Expander, AutoSuggestBox, ToolTip, PersonPicture), Simple utility brushes (overlays, scrims, measurement/debug), and the Simple-specific pink primitive scale."
+when_to_use: "Use when targeting the Uno Simple theme — setting up `SimpleTheme`, choosing Simple-only style keys (danger buttons, Small/Medium size variants, error inputs, PersonPicture variants), styling controls that exist only in Simple (Expander, AutoSuggestBox, ToolTip), overriding the Inter font or the grayscale palette, or working with Simple's utility brush family (overlays, scrims, measurement/debug)."
+metadata:
+  author: uno-platform
+  version: "1.0"
+  framework: uno-platform
+  category: themes
+---
+
+# Uno Simple Theme — Agent Skill
+
+The Simple theme is Uno's designer/wireframe-style theme. It shares the semantic surface (style keys, typography keys, color keys, brush keys) with Material via the **Semantic Design Language** — see `uno-themes-semantic-colors-brushes` for the shared layer. This skill covers the **Simple-only** style keys, brushes, and `SimpleTheme` configuration that are not portable to other themes.
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Search the docs for the topic
+
+| Topic | Search query |
+|---|---|
+| Installation / `SimpleTheme` setup | `uno_platform_docs_search("Uno Simple theme installation SimpleTheme UnoFeatures")` |
+| Simple style keys (buttons, inputs, etc.) | `uno_platform_docs_search("Uno Simple controls styles danger size variants")` |
+| `DefaultSize` (Small / Medium) | `uno_platform_docs_search("Uno Simple DefaultSize SimpleControlSize button height")` |
+| Color override / palette | `uno_platform_docs_search("Uno Simple ColorOverrideSource palette grayscale")` |
+| Font override | `uno_platform_docs_search("Uno Simple FontOverrideSource Inter font family")` |
+| Utility brushes (overlays, scrims) | `uno_platform_docs_search("Uno Simple utility brushes overlay scrim measurement")` |
+
+### Step 2: Fetch a page
+
+Uno's published docs have **no Simple-theme-specific pages** — the inline tables in this skill are the authoritative reference for Simple. For cross-theme topics, search and fetch the `sourcePath` from a result, e.g. lightweight styling:
+
+- **Lightweight Styling** (cross-theme): `external/uno.themes/doc/lightweight-styling.md`
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.themes/doc/lightweight-styling.md")
+```
+
+## Critical Rules
+
+- **Simple uses a flat grayscale palette** for all roles except Error (which uses red). Primary, Secondary, Tertiary, Surface, and Outline are achromatic grays. To introduce brand colors, override the palette via `ColorOverrideSource` / `ColorOverrideDictionary`.
+- **Simple defaults to Inter** for all typography (`SimpleFontFamily`); `CharacterSpacing=0` on all styles; font weights are `Bold` / `SemiBold` / `Normal` (no `Medium`).
+- **Typography style keys are NEVER theme-prefixed.** Write `DisplayLarge`, `BodyMedium`, `LabelSmall` — NOT `SimpleDisplayLarge`. The theme-prefix pattern only applies to the Simple-only control styles listed below.
+- **`DefaultSize` affects implicit styles only.** Setting `<SimpleTheme DefaultSize="Medium" />` switches the unsized button / icon-button / toggle-button defaults from 32px (Small) to 40px (Medium). Size-specific styles (`SimpleSmall*`, `SimpleMedium*`) always use their declared size regardless of `DefaultSize`.
+
+## SimpleTheme Configuration
+
+`SimpleTheme` (namespace `using:Uno.Simple`) accepts:
+
+| Property | Type | Default | Purpose |
+|---|---|---|---|
+| `ColorOverrideSource` | `string` (URI) | — | Path to a XAML ResourceDictionary overriding `*Color` keys |
+| `ColorOverrideDictionary` | `ResourceDictionary` | — | Inline ResourceDictionary overriding `*Color` keys |
+| `FontOverrideSource` | `string` (URI) | — | Path to a XAML ResourceDictionary overriding font resources |
+| `FontOverrideDictionary` | `ResourceDictionary` | — | Inline ResourceDictionary overriding font resources |
+| `DefaultSize` | `SimpleControlSize` | `Small` | Default size variant for buttons / icon buttons / toggle buttons |
+
+```xml
+<SimpleTheme xmlns="using:Uno.Simple"
+             ColorOverrideSource="ms-appx:///Styles/Application/ColorOverride.xaml"
+             FontOverrideSource="ms-appx:///Styles/Application/FontOverride.xaml"
+             DefaultSize="Medium" />
+```
+
+When overriding the palette, **always provide both `Light` and `Default` (Dark) theme values**.
+
+## Simple-Only Style Keys
+
+### Button Variants (no Material equivalent)
+
+| Style Key | Control | Use For |
+|---|---|---|
+| `SimpleDangerPrimaryButtonStyle` | `Button` | Destructive filled action ("Delete account") |
+| `SimpleDangerSubtleButtonStyle` | `Button` | Destructive text action |
+| `SimpleIconButtonNeutralStyle` | `Button` | Neutral (secondary) icon button |
+| `SimpleIconButtonSubtleStyle` | `Button` | Subtle (tertiary) icon button |
+| `SimpleIconButtonDangerPrimaryStyle` | `Button` | Destructive filled icon button |
+| `SimpleIconButtonDangerSubtleStyle` | `Button` | Destructive subtle icon button |
+
+### Size Variants (Small / Medium)
+
+Pattern: `Simple{Size}{Style}`. `Small` = 32px, `Medium` = 40px (button height).
+
+| Size | Button | Icon Button | ToggleButton |
+|---|---|---|---|
+| Small | `SimpleSmallFilledButtonStyle`, `SimpleSmallFilledTonalButtonStyle`, `SimpleSmallTextButtonStyle`, `SimpleSmallDangerPrimaryButtonStyle`, `SimpleSmallDangerSubtleButtonStyle` | `SimpleSmallIconButtonStyle`, `SimpleSmallIconButtonNeutralStyle`, `SimpleSmallIconButtonSubtleStyle`, `SimpleSmallIconButtonDangerPrimaryStyle`, `SimpleSmallIconButtonDangerSubtleStyle` | `SimpleSmallToggleButtonStyle` |
+| Medium | `SimpleMediumFilledButtonStyle`, `SimpleMediumFilledTonalButtonStyle`, `SimpleMediumTextButtonStyle`, `SimpleMediumDangerPrimaryButtonStyle`, `SimpleMediumDangerSubtleButtonStyle` | `SimpleMediumIconButtonStyle`, `SimpleMediumIconButtonNeutralStyle`, `SimpleMediumIconButtonSubtleStyle`, `SimpleMediumIconButtonDangerPrimaryStyle`, `SimpleMediumIconButtonDangerSubtleStyle` | `SimpleMediumToggleButtonStyle` |
+
+### Input Variants
+
+| Style Key | Control | Use For |
+|---|---|---|
+| `SimpleTextBoxErrorStyle` | `TextBox` | Error / validation state |
+| `SimpleTextBoxSmallStyle` | `TextBox` | Small size variant |
+| `SimpleComboBoxErrorStyle` | `ComboBox` | Error / validation state |
+
+### Controls Without Material Equivalent
+
+| Style Key | Control | Notes |
+|---|---|---|
+| `SimpleExpanderStyle` | `Expander` | No Material counterpart |
+| `SimpleAutoSuggestBoxStyle` | `AutoSuggestBox` | No Material counterpart |
+| `SimpleToolTipStyle` | `ToolTip` | No Material counterpart |
+| `SimplePersonPictureStyle` | `PersonPicture` | Circular, medium (default) |
+| `SimplePersonPictureSmallStyle` | `PersonPicture` | Circular, small |
+| `SimplePersonPictureLargeStyle` | `PersonPicture` | Circular, large |
+| `SimplePersonPictureSquareStyle` | `PersonPicture` | Square (rounded), medium |
+| `SimplePersonPictureSquareSmallStyle` | `PersonPicture` | Square (rounded), small |
+| `SimplePersonPictureSquareLargeStyle` | `PersonPicture` | Square (rounded), large |
+
+## Simple-Specific Utility Brushes
+
+Beyond the shared semantic brushes, Simple defines utility brushes for overlays, scrims, and measurement/debug overlays. Defined in Simple's `ColorPalette.xaml`; no shared equivalent.
+
+| Brush Key | Light | Dark | Purpose |
+|---|---|---|---|
+| `SimpleBackgroundUtilitiesBlanketBrush` | `#B2000000` | `#B2000000` | Heavy overlay / blanket |
+| `SimpleBackgroundUtilitiesMeasurementBrush` | Pink 200 | Pink 800 | Measurement overlay background |
+| `SimpleBackgroundUtilitiesOverlayBrush` | `#80000000` | `#80000000` | Semi-transparent overlay |
+| `SimpleBackgroundUtilitiesScrimBrush` | `#CCFFFFFF` | `#CC000000` | Scrim behind dialogs / sheets |
+| `SimpleTextUtilitiesOnMeasurementBrush` | Pink 800 | Pink 200 | Text on measurement surfaces |
+| `SimpleTextUtilitiesOnOverlayBrush` | `OnSurfaceInverseBrush` | `OnSurfaceBrush` | Text on overlay surfaces |
+| `SimpleIconUtilitiesBrush` | Pink 600 | Pink 400 | Measurement / debug icons |
+| `SimpleIconUtilitiesOnMeasurementBrush` | Pink 800 | Pink 200 | Icons on measurement surfaces |
+| `SimpleBorderUtilitiesMeasurementBrush` | Pink 400 | Pink 600 | Measurement / debug borders |
+| `SimpleBorderUtilitiesSwatchBrush` | `#3D000000` | `#3DFFFFFF` | Color swatch borders |
+
+These reference a Simple-specific **pink primitive scale**: `SimplePink200Color` through `SimplePink800Color`. Pink values **intentionally swap** between light and dark themes to maintain contrast.
+
+## Customization Methods
+
+Simple supports five escalating overrides (ordered by scope):
+
+1. **Override color palette (full cascade)** — `ColorOverrideSource` / `ColorOverrideDictionary` on `SimpleTheme`. All brushes cascade.
+2. **Switch default size variant** — `DefaultSize="Medium"` on `SimpleTheme`. Affects implicit button / icon-button / toggle-button styles only; size-named variants are unaffected.
+3. **Override specific brushes (targeted)** — `<SolidColorBrush x:Key="FilledButtonBackground" Color="..." />` in App.xaml.
+4. **Override per-control instance (scoped)** — wrap the brush override inside the control's `Resources` block.
+5. **Override font family** — `FontOverrideSource` / `FontOverrideDictionary` on `SimpleTheme`, or override `SimpleFontFamily` directly. Default is **Inter**.
+
+Customization precedence (highest → lowest): per-instance `Control.Resources` → `Page.Resources` → app-level overrides → `SimpleTheme` defaults → `SharedColorPalette` / `SharedColors` / `SharedTypography` foundation.
+
+## Related Skills
+
+- [[uno-themes-semantic-colors-brushes]] — **Read this first** for the shared semantic surface (style keys, typography, palette, brushes) common to Simple AND Material. Most styling should use those portable keys; reach for Simple-prefixed styles only when targeting Simple-specific concepts (danger variants, explicit sizes, Expander, etc.).
+- [[uno-themes-material]] — Material theme reference. Use when targeting Material instead of (or alongside) Simple.

--- a/skills/uno-toolkit-ancestor-binding/SKILL.md
+++ b/skills/uno-toolkit-ancestor-binding/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: uno-toolkit-ancestor-binding
+description: "Use AncestorBinding and ItemsControlBinding markup extensions for relative binding from within DataTemplates. Access parent DataContext."
+when_to_use: "Use when binding inside a `DataTemplate` needs to reach the outer `DataContext`, the page's ViewModel, or an ancestor `ItemsControl` — the Uno equivalent of WPF's `RelativeSource FindAncestor`. `ItemsControlBinding` exposes the parent ItemsControl's own `DataContext` from within its item template."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit AncestorBinding — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the AncestorBinding Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit AncestorBinding ItemsControlBinding relative binding DataTemplate ancestor")
+```
+
+Primary documentation page:
+- **AncestorBinding & ItemsControlBinding**: `external/uno.toolkit.ui/doc/helpers/ancestor-itemscontrol-binding.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/helpers/ancestor-itemscontrol-binding.md")
+```
+
+## Key Principles (Stable)
+
+- `{utu:AncestorBinding AncestorType=MyControl, Path=DataContext.MyProperty}` — binds to an ancestor's DataContext
+- `{utu:ItemsControlBinding Path=DataContext.MyCommand}` — shorthand for binding to the parent ItemsControl's DataContext
+- Similar to WPF's `{RelativeSource Mode=FindAncestor, AncestorType=...}`
+- Essential for commands in DataTemplates that need to call the page's ViewModel
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-command-extensions]] — Commands in templates

--- a/skills/uno-toolkit-autolayout/SKILL.md
+++ b/skills/uno-toolkit-autolayout/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: uno-toolkit-autolayout
+description: "Use AutoLayout control to arrange children with Figma-like spacing, alignment, and padding."
+when_to_use: "Use when building layouts that mirror Figma Auto-Layout, arranging children in rows or columns with uniform spacing, using space-between distribution, per-child alignment overrides (CounterAlignment), or converting Figma designs to XAML."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: toolkit
+---
+
+# Uno Toolkit AutoLayout — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the AutoLayout Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit AutoLayout panel Figma spacing alignment")
+```
+
+Primary documentation page:
+- **AutoLayout Control**: `external/uno.toolkit.ui/doc/controls/AutoLayoutControl.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/AutoLayoutControl.md")
+```
+
+### Step 2: For How-To Walkthroughs
+
+```
+uno_platform_docs_search("AutoLayout howto walkthrough example Figma")
+```
+
+## Key Principles (Stable)
+
+**Container properties** (set on the `<utu:AutoLayout>` element itself):
+
+- `Orientation` — Horizontal or Vertical (primary axis)
+- `Spacing` — gap between children (like Figma auto-layout spacing)
+- `Justify` — SpaceBetween distribution
+- `PrimaryAxisAlignment` — alignment on the primary axis (`Start`, `Center`, `End`, `Stretch`)
+- `CounterAxisAlignment` — alignment on the cross axis (`Start`, `Center`, `End`, `Stretch`)
+- `Padding` — Figma-anchor-style padding (`Thickness`)
+
+**Per-child attached properties** (set on children of an `AutoLayout`, **note: NOT the same names as the container properties**):
+
+- `utu:AutoLayout.PrimaryAlignment` — override on primary axis (`Auto` or `Stretch`)
+- `utu:AutoLayout.CounterAlignment` — override on counter axis (`Start`, `Center`, `End`, `Stretch`) — **`CounterAlignment`, NOT `CounterAxisAlignment`**
+- `utu:AutoLayout.PrimaryLength` — fixed size along orientation axis (`double`)
+- `utu:AutoLayout.CounterLength` — fixed size perpendicular to orientation (`double`)
+- `utu:AutoLayout.IsIndependentLayout` — absolute positioning (`bool`)
+
+There is **no** `AutoLayout.Counterpart`, no `AutoLayout.SetCounterAxisAlignment(...)`, no `AutoLayout.Align`, no `AutoLayout.MainAxis`, no `AutoLayout.CrossAxis`. If unsure, the canonical surface is the table above — do not invent member names.
+
+**XAML namespace:** `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-responsive]] — Responsive layout based on screen size

--- a/skills/uno-toolkit-card/SKILL.md
+++ b/skills/uno-toolkit-card/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: uno-toolkit-card
+description: "Use CardContentControl for elevated, filled, or outlined card containers."
+when_to_use: "ALWAYS use this skill when building any card-like UI — elevated, filled, or outlined containers. ALWAYS use `CardContentControl` — never use `Card` (it has rigid predefined slots that limit layout flexibility). ALWAYS use this skill instead of creating a `Border` used as a card (with `CornerRadius` combined with `Background`, `Padding`, or `BorderBrush`) — `CardContentControl` provides proper styling, elevation, and theming out of the box. Custom card layouts with full control over content via `ContentTemplate`."
+metadata:
+  author: uno-platform
+  version: "3.6"
+  category: toolkit
+---
+
+# Uno Toolkit CardContentControl — Agent Skill
+
+## Critical Rules
+
+- **NEVER use `Card`** — always use `CardContentControl`. The `Card` control has rigid predefined slots (HeaderContent, SubHeaderContent, AvatarContent, etc.) that constrain layout. `CardContentControl` gives full layout freedom via `ContentTemplate`.
+- **NEVER use `Border` with `CornerRadius` to wrap content.** This is the most common Border anti-pattern in generated XAML and the parser flags it as `GRD1102`. Always use `CardContentControl` instead — it provides correct elevation, corner radius, theming, and accessibility automatically.
+
+### Anti-pattern detection (matches `GRD1102`)
+
+If you find yourself writing a `<Border>` that meets **all** of the following, stop and rewrite it as `utu:CardContentControl`:
+
+1. The `Border` has children (it is **not** self-closing).
+2. It sets `CornerRadius` to a non-zero value.
+3. It sets at least one of: `Background`, `BorderBrush` (with non-zero `BorderThickness`), or non-zero `Padding`.
+
+That's a card. `<Border CornerRadius="8" Background="..." Padding="16">…</Border>` is a card written the wrong way.
+
+```xml
+<!-- WRONG: Border-as-card (the parser will report GRD1102) -->
+<Border CornerRadius="8"
+        Background="{ThemeResource SurfaceBrush}"
+        Padding="16">
+    <StackPanel Spacing="8">
+        <TextBlock Text="Title"/>
+        <TextBlock Text="Body"/>
+    </StackPanel>
+</Border>
+
+<!-- CORRECT: utu:CardContentControl -->
+<utu:CardContentControl Style="{StaticResource ElevatedCardContentControlStyle}">
+    <utu:CardContentControl.ContentTemplate>
+        <DataTemplate>
+            <StackPanel Padding="16" Spacing="8">
+                <TextBlock Text="Title"/>
+                <TextBlock Text="Body"/>
+            </StackPanel>
+        </DataTemplate>
+    </utu:CardContentControl.ContentTemplate>
+</utu:CardContentControl>
+```
+
+### When `Border` is still correct
+
+`Border` is the right choice for: dividers (`<Border Height="1" Background="..."/>`), thin separators, simple background fills with no rounded corners, image/content clipping with `CornerRadius` alone (no `Background`/`Padding`/`BorderBrush+BorderThickness`), and layout primitives **inside** a `ControlTemplate`. The grader specifically targets the *card-shaped* combination above; plain layout borders are unaffected.
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the CardContentControl Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit CardContentControl elevated filled outlined")
+```
+
+Primary documentation page:
+- **Card & CardContentControl**: `external/uno.toolkit.ui/doc/controls/CardAndCardContentControl.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/CardAndCardContentControl.md")
+```
+
+### Step 2: For How-To / Walkthrough
+
+```
+uno_platform_docs_search("CardContentControl howto walkthrough custom template")
+```
+
+Key page:
+- **Card How-To**: `external/uno.toolkit.ui/doc/controls/walkthroughs/Card-and-CardContentControl.howto.md`
+
+## Key Principles (Stable)
+
+- **`CardContentControl`** — fully custom layout via `ContentTemplate`. This is the only card control you should use.
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+- Do NOT use `Card` — it has predefined slots that limit layout flexibility
+- Do NOT use `Border` as a card (`CornerRadius` + `Background`/`Padding`/`BorderBrush`) — the parser reports this as `GRD1102`; use `CardContentControl` instead
+
+## Critical: Content Binding in DataTemplates
+
+When `CardContentControl` is used **inside** an `ItemsRepeater`, `ListView`, or any other `DataTemplate`, you **MUST** set `Content="{Binding}"` on the `CardContentControl`. Without this, the inner `ContentTemplate > DataTemplate` has **no DataContext** and all bindings inside it resolve to null (rendering the card empty/invisible).
+
+### Rules
+
+- **ALWAYS** set `Content="{Binding}"` on `CardContentControl` when it appears inside a `DataTemplate`
+- **NEVER** use indexed bindings (e.g. `{Binding Items[0].Label}`) inside card templates — use `ItemsSource` with a nested `ItemsRepeater` instead
+- The `ContentTemplate`'s inner `DataTemplate` inherits its DataContext **only** from the `Content` property — if `Content` is not bound, the inner template has no data
+
+### Correct pattern
+
+```xml
+<DataTemplate x:DataType="local:MenuItem">
+  <utu:CardContentControl Style="{StaticResource FilledCardContentControlStyle}"
+                           Content="{Binding}">
+    <utu:CardContentControl.ContentTemplate>
+      <DataTemplate>
+        <TextBlock Text="{Binding Label}" />
+      </DataTemplate>
+    </utu:CardContentControl.ContentTemplate>
+  </utu:CardContentControl>
+</DataTemplate>
+```
+
+### Wrong pattern (missing Content binding)
+
+```xml
+<!-- ❌ WRONG: No Content="{Binding}" — inner DataTemplate has no DataContext -->
+<DataTemplate x:DataType="local:MenuItem">
+  <utu:CardContentControl Style="{StaticResource FilledCardContentControlStyle}">
+    <utu:CardContentControl.ContentTemplate>
+      <DataTemplate>
+        <TextBlock Text="{Binding Label}" />  <!-- This resolves to null! -->
+      </DataTemplate>
+    </utu:CardContentControl.ContentTemplate>
+  </utu:CardContentControl>
+</DataTemplate>
+```
+
+## Sizing — `CardContentControl` does NOT stretch by default
+
+`CardContentControl` sizes to its content. It will **not** fill the available width or height of its parent on its own, even inside a `Grid` cell or `StackPanel` slot that has space to spare. If you need the card to take all available space (a hero card, a full-width row, a column-filling pane), set the alignment **explicitly** on the `CardContentControl` itself:
+
+```xml
+<!-- Card fills its grid cell horizontally and vertically -->
+<utu:CardContentControl Grid.Row="0"
+                        Style="{StaticResource ElevatedCardContentControlStyle}"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch">
+    <utu:CardContentControl.ContentTemplate>
+        <DataTemplate>
+            <Grid Padding="16">
+                <!-- ... -->
+            </Grid>
+        </DataTemplate>
+    </utu:CardContentControl.ContentTemplate>
+</utu:CardContentControl>
+```
+
+Rules of thumb:
+
+- **Full-width row card** (e.g. summary card across a page): `HorizontalAlignment="Stretch"`.
+- **Column- or pane-filling card** (e.g. a card that should fill a `*` row in a `Grid`): `HorizontalAlignment="Stretch"` **and** `VerticalAlignment="Stretch"`.
+- **Card inside an `ItemsRepeater`/`ListView` item template that should fill the item slot**: `HorizontalAlignment="Stretch"`.
+- **Compact / chip-style card sized to its content**: leave alignment unset (default behavior).
+
+Setting `Width`/`Height` on the inner content of the `ContentTemplate` will not stretch the card — the alignment must be set on the `CardContentControl` element.
+
+## Style Variants
+
+`CardContentControl` exposes three semantic style keys. Each design-theme provides its own concrete look; the key names are shared across themes.
+
+| Style | When to use |
+|-------|-------------|
+| `ElevatedCardContentControlStyle` | Subtle z-axis elevation; default choice for surfaced content |
+| `FilledCardContentControlStyle` | Background tint, no elevation; use on busy backgrounds |
+| `OutlinedCardContentControlStyle` | Stroke instead of fill/elevation; secondary content |
+
+## Related Skills
+
+- [[uno-toolkit-shadowcontainer]] — Custom shadow effects
+- [[uno-toolkit-lightweight-styling]] — Resource key overrides for cards

--- a/skills/uno-toolkit-chip/SKILL.md
+++ b/skills/uno-toolkit-chip/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: uno-toolkit-chip
+description: "Use Chip and ChipGroup for selection, filtering, or action triggers. Supports Assist, Input, Filter, and Suggestion chip styles."
+when_to_use: "Use when building filter bars, tag input, multi-select pills, or suggestion chips — the Assist, Input, Filter, and Suggestion chip patterns. `ChipGroup` handles single or multi-selection; chips support leading icons and a remove button."
+metadata:
+  author: uno-platform
+  version: "2.5"
+  category: toolkit
+---
+
+# Uno Toolkit Chip — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Chip Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit Chip ChipGroup filter assist input suggestion")
+```
+
+Primary documentation page:
+- **Chip & ChipGroup**: `external/uno.toolkit.ui/doc/controls/ChipAndChipGroup.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/ChipAndChipGroup.md")
+```
+
+### Step 2: For How-To / Walkthrough
+
+```
+uno_platform_docs_search("Chip ChipGroup howto walkthrough selection filter")
+```
+
+## Key Principles (Stable)
+
+- `Chip` is derived from `ToggleButton` — can be checked/unchecked
+- Styles: `AssistChipStyle`, `InputChipStyle`, `FilterChipStyle`, `SuggestionChipStyle`
+- `ChipGroup` manages a collection of chips with `SelectionMode` (Single, Multiple, None)
+- `CanRemove="True"` enables a remove button on the chip
+- Icon support via `Icon` property
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-selector-extensions]] — Selection behavior extensions

--- a/skills/uno-toolkit-command-extensions/SKILL.md
+++ b/skills/uno-toolkit-command-extensions/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: uno-toolkit-command-extensions
+description: "Attached properties (`CommandExtensions.Command`, `CommandExtensions.CommandParameter`) that bind controls without a built-in `Command` to MVVM commands."
+when_to_use: "Use when a UI event (Enter in `TextBox`, item click in `ListView`, `ToggleSwitch` toggle, `NavigationViewItem` invocation, any `UIElement` tap) must invoke an MVVM command without code-behind event handlers."
+metadata:
+  author: uno-platform
+  version: "2.5"
+  category: toolkit
+---
+
+# Uno Toolkit Command Extensions — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the CommandExtensions Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit CommandExtensions command TextBox enter ToggleSwitch ListView tap")
+```
+
+Primary documentation pages:
+- **CommandExtensions (Chefs)**: `external/uno.chefs/doc/toolkit/CommandExtensions.md`
+- **Command Extensions helper**: search for `CommandExtensions` in toolkit helpers
+
+Fetch the Chefs page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.chefs/doc/toolkit/CommandExtensions.md")
+```
+
+### Step 2: For Reference Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit CommandExtensions attached property Command CommandParameter")
+```
+
+## Critical Rules
+
+- There is **no `CommandTrigger` attached property**. `utu:CommandExtensions.Command="{Binding ...}"` alone is sufficient — the trigger event is determined automatically by the control type (Enter on `TextBox`/`PasswordBox`, item click on `ListView`, toggle on `ToggleSwitch`, invocation on `NavigationView`, tap on any `UIElement`). Do not invent a separate trigger property.
+- `Command` on `ListView` requires `IsItemClickEnabled="True"` to fire.
+
+## Key Principles (Stable)
+
+- `utu:CommandExtensions.Command="{Binding MyCommand}"` — attaches a command
+- `utu:CommandExtensions.CommandParameter` — optional parameter
+- Supported controls: TextBox (enter key), PasswordBox, ToggleSwitch, ListView, NavigationView, ItemsRepeater, any UIElement (tap)
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-input-extensions]] — Input field focus flow
+- [[uno-toolkit-itemsrepeater-extensions]] — ItemsRepeater selection

--- a/skills/uno-toolkit-csharp-markup/SKILL.md
+++ b/skills/uno-toolkit-csharp-markup/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: uno-toolkit-csharp-markup
+description: "Use C# Markup with Uno Toolkit controls instead of XAML. Setup, NuGet packages, and fluent API patterns."
+when_to_use: "Use when the project uses C# Markup instead of XAML and needs the Toolkit's fluent extension methods, setting up the `Uno.Toolkit.WinUI.Markup` NuGet package, applying Toolkit styles, extensions, and helpers in C# Markup, or converting existing XAML Toolkit usage to C# Markup."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit C# Markup — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the C# Markup Toolkit Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit C# Markup fluent API setup NuGet package")
+```
+
+Primary documentation pages:
+- **Toolkit C# Markup**: `external/uno.toolkit.ui/doc/getting-started.md`
+- **Material Toolkit C# Markup**: `external/uno.toolkit.ui/doc/material-getting-started.md`
+- **Chefs C# Markup Toolkit Tutorial**: `external/uno.extensions/doc/Learn/Markup/HowTo-CustomMarkupProject-Toolkit.md`
+
+Fetch the Chefs tutorial:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.extensions/doc/Learn/Markup/HowTo-CustomMarkupProject-Toolkit.md")
+```
+
+## Key Principles (Stable)
+
+- Add `Uno.Toolkit.WinUI.Markup` NuGet package
+- For Material: add `Uno.Toolkit.WinUI.Material.Markup` NuGet package
+- Fluent API: `new Card().Style(Theme.Card.Styles.Elevated)`
+- Same controls and helpers, expressed in C# instead of XAML
+
+## Related Skills
+
+- [[uno-toolkit-getting-started]] — Base Toolkit setup
+- [[uno-themes-material]] — Material C# Markup

--- a/skills/uno-toolkit-cupertino-theme/SKILL.md
+++ b/skills/uno-toolkit-cupertino-theme/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: uno-toolkit-cupertino-theme
+description: "Configure Uno Cupertino Toolkit with CupertinoToolkitTheme for iOS-style Toolkit controls."
+when_to_use: "Use when targeting iOS-styled UI and replacing `MaterialToolkitTheme` with `CupertinoToolkitTheme` in App.xaml, implementing Apple Human Interface Guidelines styling, or applying the Cupertino design system to Toolkit controls."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit Cupertino Theme — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Cupertino Toolkit Documentation
+
+```
+uno_platform_docs_search("Uno Cupertino Toolkit CupertinoToolkitTheme getting started")
+```
+
+Primary documentation page:
+- **Cupertino Toolkit Getting Started**: `external/uno.toolkit.ui/doc/cupertino-getting-started.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/cupertino-getting-started.md")
+```
+
+## Key Principles (Stable)
+
+- `CupertinoToolkitTheme` is the unified approach for Cupertino-styled Toolkit controls
+- Place in App.xaml `<Application.Resources>`
+- Requires `Toolkit` in `<UnoFeatures>`
+- Cupertino and Material themes are mutually exclusive
+
+## Related Skills
+
+- [[uno-toolkit-getting-started]] — Base Toolkit setup
+- [[uno-toolkit-material-theme]] — Material alternative

--- a/skills/uno-toolkit-divider/SKILL.md
+++ b/skills/uno-toolkit-divider/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: uno-toolkit-divider
+description: "Use Divider control to create visual separators between content sections. A thin line with optional subheader text."
+when_to_use: "Use when separating list, form, or settings sections with a thin rule, with or without a subheader label. Supports horizontal and vertical orientations and lightweight styling via resource keys."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit Divider — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Divider Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit Divider separator thin line subheader")
+```
+
+Primary documentation page:
+- **Divider**: `external/uno.toolkit.ui/doc/controls/Divider.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/Divider.md")
+```
+
+## Key Principles (Stable)
+
+- Simple thin line separator
+- Optional `SubHeader` text property
+- Supports lightweight styling via resource keys
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-lightweight-styling]] — Customizing divider appearance

--- a/skills/uno-toolkit-drawer/SKILL.md
+++ b/skills/uno-toolkit-drawer/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: uno-toolkit-drawer
+description: "Use DrawerControl for swipe-gesture navigation drawers and DrawerFlyoutPresenter for bottom/side sheet flyouts."
+when_to_use: "Use when adding swipe-to-open side drawers, bottom sheets, or modal flyout panels. `DrawerControl` for a full drawer layout with main + slide-in content; `DrawerFlyoutPresenter` for gesture-enabled `Flyout` presenters."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit Drawer — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Drawer Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit DrawerControl DrawerFlyoutPresenter swipe sheet")
+```
+
+Primary documentation page:
+- **DrawerControl**: `external/uno.toolkit.ui/doc/controls/DrawerControl.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/DrawerControl.md")
+```
+
+### Step 2: For DrawerFlyoutPresenter
+
+If the user needs gesture-enabled flyouts:
+
+```
+uno_platform_docs_search("Uno Toolkit DrawerFlyoutPresenter flyout bottom sheet gesture")
+```
+
+## Key Principles (Stable)
+
+- `DrawerControl` has a main content area and a drawer that slides in
+- `DrawerOpenDirection` — Left, Right, Up, Down
+- `IsOpen` property controls drawer state (bindable)
+- `DrawerFlyoutPresenter` — adds swipe gesture support to standard Flyouts
+- `DrawerLength` — size of the drawer
+- Supports light dismiss (tap outside to close)
+
+## Related Skills
+
+- [[uno-navigation-dialogs]] — Dialog/flyout via navigation

--- a/skills/uno-toolkit-extendedsplashscreen/SKILL.md
+++ b/skills/uno-toolkit-extendedsplashscreen/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: uno-toolkit-extendedsplashscreen
+description: "Use ExtendedSplashScreen to display a loading screen that extends the native splash screen appearance."
+when_to_use: "Use when extending the native splash screen during app initialization, showing loading progress during startup, custom startup loading content, or android requires `Init()` call in MainActivity."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: toolkit
+---
+
+# Uno Toolkit ExtendedSplashScreen — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the ExtendedSplashScreen Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit ExtendedSplashScreen splash loading startup Init")
+```
+
+Primary documentation page:
+- **ExtendedSplashScreen**: search results will provide the control page
+
+Fetch results and look for the control documentation:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls-styles.md")
+```
+
+Search for ExtendedSplashScreen in the controls list.
+
+### Step 2: For Navigation Integration
+
+ExtendedSplashScreen often works with Navigation Extensions for Shell startup:
+
+See the `uno-navigation-setup` skill.
+
+## Key Principles (Stable)
+
+- Based on `LoadingView` — shows native splash image with custom loading content
+- Requires `Init()` call on Android in `MainActivity.OnCreate`
+- Do NOT use `Region.Attached="True"` inside ExtendedSplashScreen content
+- Content is shown on top of the native splash screen image
+- Loading screen visuals (splash image, background color) are primarily controlled by **Resizetizer** configuration
+
+## Related Skills
+
+- [[uno-toolkit-loadingview]] — Base loading control
+- [[uno-navigation-setup]] — Navigation host setup

--- a/skills/uno-toolkit-flipview-extensions/SKILL.md
+++ b/skills/uno-toolkit-flipview-extensions/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: uno-toolkit-flipview-extensions
+description: "Use FlipViewExtensions to add navigation buttons to FlipView. Auto-shows Previous/Next arrows for desktop."
+when_to_use: "Use when a `FlipView` needs Previous/Next arrow buttons on desktop (the default touch swipe is mouse-hostile). Buttons auto-show on desktop and can be styled via attached properties."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit FlipView Extensions — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the FlipView Extensions Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit FlipView extensions navigation buttons previous next arrows")
+```
+
+### Step 2: For Reference
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls-styles.md")
+```
+
+Look for FlipViewExtensions in the helpers section.
+
+## Key Principles (Stable)
+
+- Shows Previous/Next navigation arrows on FlipView
+- Buttons auto-show on hover for desktop
+- Customizable button templates via default chevron styles
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- (standalone helper, no primary dependencies)

--- a/skills/uno-toolkit-getting-started/SKILL.md
+++ b/skills/uno-toolkit-getting-started/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: uno-toolkit-getting-started
+description: "Install and configure Uno Toolkit library in Uno Platform applications."
+when_to_use: "Use when setting up Uno Toolkit in a new or existing project, adding `<UnoFeatures>Toolkit</UnoFeatures>` to a project, configuring ToolkitResources or MaterialToolkitTheme in App.xaml, or understanding Toolkit NuGet package requirements."
+metadata:
+  author: uno-platform
+  version: "2.3"
+  category: toolkit
+---
+
+# Uno Toolkit Getting Started — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Getting Started Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit getting started install UnoFeatures ToolkitResources")
+```
+
+Primary documentation pages:
+- **Getting Started (base Toolkit)**: `external/uno.toolkit.ui/doc/getting-started.md`
+- **Material Toolkit Getting Started**: `external/uno.toolkit.ui/doc/material-getting-started.md`
+
+Fetch the getting started page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/getting-started.md")
+```
+
+### Step 2: For Material Design Toolkit
+
+If user needs Material Design styled toolkit controls:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/material-getting-started.md")
+```
+
+### Step 3: For Available Controls and Helpers
+
+To see the full list of Toolkit controls and helpers:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls-styles.md")
+```
+
+## Key Principles (Stable)
+
+- Add `Toolkit` to `<UnoFeatures>` in the project file
+- For Material styling, use `MaterialToolkitTheme` in App.xaml (replaces separate MaterialTheme + ToolkitResources)
+- For Cupertino styling, use `CupertinoToolkitTheme`
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+- CLI: `dotnet new unoapp -o MyApp -toolkit` to create a new project with Toolkit
+
+## Related Skills
+
+- [[uno-toolkit-material-theme]] — MaterialToolkitTheme configuration
+- [[uno-toolkit-cupertino-theme]] — CupertinoToolkitTheme configuration
+- [[uno-themes-material]] — Material theme installation

--- a/skills/uno-toolkit-input-extensions/SKILL.md
+++ b/skills/uno-toolkit-input-extensions/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: uno-toolkit-input-extensions
+description: "Use InputExtensions for form input UX improvements including auto-focus next field, auto-dismiss keyboard, and custom return key types."
+when_to_use: "Use when implementing forms that auto-advance focus on Enter, dismiss the keyboard on completion, or set platform-specific return key types (Next, Done, Search) — typically login forms or multi-field input sequences on mobile."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit Input Extensions — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the InputExtensions Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit InputExtensions auto focus next dismiss keyboard return type")
+```
+
+Primary documentation pages:
+- **Input Extensions**: `external/uno.toolkit.ui/doc/helpers/Input-extensions.md`
+- **Input Extensions How-To**: `external/uno.toolkit.ui/doc/helpers/walkthroughs/input-extensions.howto.md`
+
+Fetch the helper reference:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/helpers/Input-extensions.md")
+```
+
+### Step 2: For Login Form Example
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/helpers/walkthroughs/input-extensions.howto.md")
+```
+
+## Key Principles (Stable)
+
+- `utu:InputExtensions.AutoFocusNext="True"` — moves focus to next field on Enter
+- `utu:InputExtensions.AutoDismiss="True"` — dismisses keyboard on last field Enter
+- `utu:InputExtensions.ReturnType="Next|Done|Search|Send|Go"` — mobile keyboard button
+- Essential for login forms and any multi-field input
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-safearea]] — Keyboard-aware safe area for forms
+- [[uno-toolkit-command-extensions]] — Command on TextBox enter

--- a/skills/uno-toolkit-itemsrepeater-extensions/SKILL.md
+++ b/skills/uno-toolkit-itemsrepeater-extensions/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: uno-toolkit-itemsrepeater-extensions
+description: "Attached properties (`utu:ItemsRepeaterExtensions.SelectionMode`, `.SelectedItem`, `.SelectedItems`, `.SelectedIndex`, `.SelectedIndexes`) that add selection and incremental loading to `ItemsRepeater`."
+when_to_use: "Use when `ItemsRepeater` needs selection or fetch-on-scroll — `ItemsRepeater` itself has no built-in `SelectionMode` / `SelectedItem`, so the Toolkit's attached properties are the canonical way to add them. Pairs with `ISupportIncrementalLoading` on the data source for automatic page loading."
+metadata:
+  author: uno-platform
+  version: "2.5"
+  category: toolkit
+---
+
+# Uno Toolkit ItemsRepeater Extensions — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the ItemsRepeater Extensions Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit ItemsRepeater extensions selection SelectedItem incremental loading")
+```
+
+Primary documentation:
+
+```
+uno_platform_docs_search("ItemsRepeaterExtensions SelectedItem SelectedItems SelectionMode incremental")
+```
+
+### Step 2: For Controls Reference
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls-styles.md")
+```
+
+Look for ItemsRepeaterExtensions in the helpers section.
+
+## Key Principles (Stable)
+
+- `utu:ItemsRepeaterExtensions.SelectedItem` — single selected item (bindable)
+- `utu:ItemsRepeaterExtensions.SelectedIndex` — single selection index (bindable)
+- `utu:ItemsRepeaterExtensions.SelectedItems` — multiple selected items (bindable)
+- `utu:ItemsRepeaterExtensions.SelectedIndexes` — multiple selection indexes (bindable)
+- `utu:ItemsRepeaterExtensions.SelectionMode` — Single, Multiple, None
+- Supports `ISupportIncrementalLoading` for automatic data fetching on scroll
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-selector-extensions]] — Selection on Selector-based controls
+- [[uno-toolkit-command-extensions]] — Command on ItemsRepeater tap

--- a/skills/uno-toolkit-lightweight-styling/SKILL.md
+++ b/skills/uno-toolkit-lightweight-styling/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: uno-toolkit-lightweight-styling
+description: "Apply lightweight styling to Uno Toolkit controls by overriding resource keys. Change colors, fonts, spacing without custom styles."
+when_to_use: "Use when customising Toolkit control appearance by overriding resource keys (colors, fonts, spacing) rather than rewriting templates. Overrides may live at app, page, or per-control scope; the main task is finding the right resource key in the naming pattern."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit Lightweight Styling — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Lightweight Styling Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit lightweight styling resource keys override controls")
+```
+
+Primary documentation page:
+- **Toolkit Lightweight Styling**: `external/uno.toolkit.ui/doc/lightweight-styling.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/lightweight-styling.md")
+```
+
+### Step 2: For Specific Control Resource Keys
+
+Each control's documentation page lists its resource keys. Search for the specific control:
+
+```
+uno_platform_docs_search("Uno Toolkit [ControlName] lightweight styling resource keys")
+```
+
+## Key Principles (Stable)
+
+- Override resource keys at App, Page, or Control level
+- Resource keys follow naming patterns: `{ControlName}{State}{Property}`
+- Control-level overrides use `<Control.Resources>` or `ResourceExtensions`
+- No need to redefine entire styles/templates
+- Each control's doc page lists available resource keys
+
+## Related Skills
+
+- [[uno-toolkit-resource-extensions]] — Per-control resource dictionary
+- [[uno-themes-material]] — Material design lightweight styling

--- a/skills/uno-toolkit-loadingview/SKILL.md
+++ b/skills/uno-toolkit-loadingview/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: uno-toolkit-loadingview
+description: "Use LoadingView to display loading indicators while async operations execute. Binds to ILoadable sources like AsyncCommand."
+when_to_use: "Use when a view must show a spinner or skeleton while an `IAsyncCommand`, `IFeed`, or `IState` is in flight, binding `LoadingView` to any `ILoadable` source, composing multiple in-flight operations via `CompositeLoadableSource`, or toggling the loading visual automatically as commands execute."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit LoadingView — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the LoadingView Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit LoadingView loading indicator ILoadable AsyncCommand")
+```
+
+Primary documentation page:
+- **LoadingView**: `external/uno.toolkit.ui/doc/controls/LoadingView.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/LoadingView.md")
+```
+
+### Step 2: For How-To / Walkthrough
+
+```
+uno_platform_docs_search("LoadingView howto walkthrough AsyncCommand loading")
+```
+
+## Key Principles (Stable)
+
+- `Source` property binds to an `ILoadable` (like `AsyncCommand`)
+- Loading content is displayed when the source is busy
+- `CompositeLoadableSource` combines multiple ILoadable sources
+- `LoadingContent` — custom content shown during loading (default is ProgressRing)
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-progress-extensions]] — ProgressBar/ProgressRing loading binding
+- [[uno-toolkit-extendedsplashscreen]] — App startup loading

--- a/skills/uno-toolkit-material-theme/SKILL.md
+++ b/skills/uno-toolkit-material-theme/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: uno-toolkit-material-theme
+description: "Configure Uno Material Toolkit with MaterialToolkitTheme for Material Design 3 styled Toolkit controls. Includes color and font customization."
+when_to_use: "Use when wiring a Material Design 3 styled Uno Toolkit shell. `MaterialToolkitTheme` in App.xaml replaces the separate `MaterialTheme` + `ToolkitResources` pair and accepts color and font customisation in its constructor."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit Material Theme — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Material Toolkit Getting Started
+
+```
+uno_platform_docs_search("Uno Material Toolkit MaterialToolkitTheme configuration App.xaml")
+```
+
+Primary documentation page:
+- **Material Toolkit Getting Started**: `external/uno.toolkit.ui/doc/material-getting-started.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/material-getting-started.md")
+```
+
+### Step 2: For Color/Font Customization
+
+Customization is done via `MaterialToolkitTheme` properties:
+
+```
+uno_platform_docs_search("MaterialToolkitTheme color font override customize palette")
+```
+
+## Key Principles (Stable)
+
+- `MaterialToolkitTheme` is the unified approach — replaces separate `MaterialTheme` + `ToolkitResources`
+- Place in App.xaml `<Application.Resources>` section
+- Supports `ColorOverrideSource` and `FontOverrideSource` for customization
+- Requires `Toolkit` in `<UnoFeatures>`
+
+## Related Skills
+
+- [[uno-toolkit-getting-started]] — Base Toolkit setup
+- [[uno-themes-material]] — Material theme (non-Toolkit): installation, color palette customization, typography, control styles

--- a/skills/uno-toolkit-navigationbar/SKILL.md
+++ b/skills/uno-toolkit-navigationbar/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: uno-toolkit-navigationbar
+description: "Page-level app bar with title, back button, and action items; renders natively on iOS and Android."
+when_to_use: "Use when adding a page-level app bar with title, back button (`MainCommand`), and `AppBarButton` actions in `PrimaryCommands` / `SecondaryCommands`. Renders as XAML on Windows and as the native bar on iOS / Android."
+metadata:
+  author: uno-platform
+  version: "2.5"
+  category: toolkit
+---
+
+# Uno Toolkit NavigationBar — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the NavigationBar Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit NavigationBar app bar MainCommand PrimaryCommands")
+```
+
+Primary documentation page:
+- **NavigationBar**: `external/uno.toolkit.ui/doc/controls/NavigationBar.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/NavigationBar.md")
+```
+
+### Step 2: For Chefs Examples
+
+```
+uno_platform_docs_search("NavigationBar Chefs app example navigation back")
+```
+
+## Critical Rules
+
+- **`MainCommand` is an `AppBarButton`** — there is no dedicated `NavigationBarMainCommand` type. Use `<utu:NavigationBar.MainCommand><AppBarButton Icon="Back" Command="{Binding GoBackCommand}"/></utu:NavigationBar.MainCommand>` (or equivalent attribute form). The same `AppBarButton` type is used for `PrimaryCommands` and `SecondaryCommands` items.
+
+## Key Principles (Stable)
+
+- `MainCommand` — the back-button slot; an `AppBarButton` instance
+- `PrimaryCommands` — action `AppBarButton`s displayed on the right
+- `SecondaryCommands` — overflow `AppBarButton`s in the overflow menu
+- Two rendering modes: `Windows` (XAML drawn) and `Native` (platform AppBar on iOS/Android)
+- Content property is the title
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-safearea]] — Safe area insets with NavigationBar
+- [[uno-navigation-code]] — Navigation integration

--- a/skills/uno-toolkit-progress-extensions/SKILL.md
+++ b/skills/uno-toolkit-progress-extensions/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: uno-toolkit-progress-extensions
+description: "Use ProgressExtensions to toggle all ProgressRing and ProgressBar controls under a sub-visual-tree with a single binding."
+when_to_use: "Use when toggling every `ProgressRing` and `ProgressBar` inside a subtree with one boolean binding, instead of binding each control individually."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit Progress Extensions — Agent Skill
+
+## Workflow
+
+### Step 1: Fetch the ProgressExtensions Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit ProgressExtensions progress bar ring ILoadable async command")
+```
+
+Primary documentation:
+
+```
+uno_platform_docs_search("ProgressExtensions IsActive source loadable progress")
+```
+
+## Key Principles (Stable)
+
+- `utu:ProgressExtensions.IsExecuting` — attached boolean property on a parent element that toggles all `ProgressRing` and `ProgressBar` controls in its sub-visual-tree
+- Acts on `ProgressRing.IsActive` and `ProgressBar.IsIndeterminate` properties of descendant controls
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-loadingview]] — LoadingView for full-content loading states

--- a/skills/uno-toolkit-resource-extensions/SKILL.md
+++ b/skills/uno-toolkit-resource-extensions/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: uno-toolkit-resource-extensions
+description: "Use ResourceExtensions to apply ResourceDictionary directly to control styles for lightweight styling. Enables visual variants without page-level resources."
+when_to_use: "Use when applying a `ResourceDictionary` directly to a single control so it picks up a visual variant without declaring resources at page level — typically per-control color or brush overrides, or shared-base-style variants."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit Resource Extensions — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the ResourceExtensions Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit ResourceExtensions ResourceDictionary style lightweight inline")
+```
+
+Primary documentation pages:
+- **ResourceExtensions (Chefs)**: `external/uno.chefs/doc/toolkit/ResourceExtensions.md`
+
+Fetch the Chefs page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.chefs/doc/toolkit/ResourceExtensions.md")
+```
+
+### Step 2: For Reference Documentation
+
+```
+uno_platform_docs_search("ResourceExtensions Resources attached property dictionary override")
+```
+
+## Key Principles (Stable)
+
+- `utu:ResourceExtensions.Resources` — attaches a ResourceDictionary to a control
+- Enables per-control resource key overrides without nesting in page resources
+- Great for creating multiple visual variants of the same control
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-lightweight-styling]] — General lightweight styling approach
+- [[uno-themes-material]] — Material lightweight styling

--- a/skills/uno-toolkit-responsive/SKILL.md
+++ b/skills/uno-toolkit-responsive/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: uno-toolkit-responsive
+description: "Screen-size-based UI adaptation via the `ResponsiveExtension` markup extension and `ResponsiveView` control."
+when_to_use: "Use when one layout must adapt to phone, tablet, or desktop, when XAML needs per-breakpoint property values (font size, orientation, padding, margin), or when an entire view subtree differs by screen size. `ResponsiveExtension` swaps property values; `ResponsiveView` swaps entire `DataTemplate`s. Custom breakpoints via `ResponsiveLayout`."
+metadata:
+  author: uno-platform
+  version: "2.5"
+  category: toolkit
+---
+
+# Uno Toolkit Responsive — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the ResponsiveExtension Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit ResponsiveExtension responsive screen size breakpoints property")
+```
+
+Primary documentation pages:
+- **ResponsiveExtension**: `external/uno.toolkit.ui/doc/helpers/responsive-extension.md`
+- **ResponsiveView**: `external/uno.toolkit.ui/doc/controls/ResponsiveView.md`
+
+Fetch ResponsiveExtension:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/helpers/responsive-extension.md")
+```
+
+### Step 2: For ResponsiveView (Template Switching)
+
+Fetch ResponsiveView for swapping entire layouts:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/ResponsiveView.md")
+```
+
+### Step 3: For How-To Examples
+
+```
+uno_platform_docs_search("ResponsiveExtension howto walkthrough responsive layout breakpoints")
+```
+
+Key page:
+- **ResponsiveExtension How-To**: `external/uno.toolkit.ui/doc/helpers/walkthroughs/responsive-extension.howto.md`
+
+## Critical Rules
+
+- **`ResponsiveExtension` must be used as a markup extension** — `{utu:Responsive Narrow=Red, Wide=Blue}` — never as a XAML element (`<utu:ResponsiveExtension .../>`). The XAML engine parses the breakpoint values as strings and performs type conversion through `MarkupExtension.ProvideValue`, which is only available in markup-extension form.
+- On Windows UWP targets, `ResponsiveExtension` only works with `string` value properties due to a `MarkupExtension.ProvideValue(IXamlServiceProvider)` limitation. For non-string properties on Windows UWP, declare the values as resources and pass them via `{StaticResource ...}` (see Uno Toolkit docs).
+
+## Key Principles (Stable)
+
+- **ResponsiveExtension** — sets property values per breakpoint (Narrow, Normal, Wide, etc.) via the `{utu:Responsive ...}` markup-extension form
+- **ResponsiveView** — swaps entire DataTemplates per breakpoint (used as an element)
+- Default breakpoints: Narrowest (150), Narrow (300), Normal (600), Wide (800), Widest (1080)
+- Custom breakpoints via `ResponsiveLayout` resource
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-navigation-responsive-shell]] — Responsive navigation shells

--- a/skills/uno-toolkit-safearea/SKILL.md
+++ b/skills/uno-toolkit-safearea/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: uno-toolkit-safearea
+description: "Use SafeArea to keep content within visible screen bounds, avoiding notches, status bars, and on-screen keyboards. Essential for mobile forms."
+when_to_use: "Use when laying out forms, footers, or bottom navigation that must clear iOS home-indicator, Android gesture bar, device notches, rounded corners, the status bar, or the on-screen keyboard. CRITICAL for any mobile page with a `TextBox` or `PasswordBox`. Apply via the `<SafeArea>` control or the `SafeArea.Insets` attached property."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit SafeArea — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the SafeArea Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit SafeArea insets notch keyboard mobile form")
+```
+
+Primary documentation pages:
+- **SafeArea Control**: `external/uno.toolkit.ui/doc/controls/SafeArea.md`
+- **SafeArea How-To**: `external/uno.toolkit.ui/doc/controls/walkthroughs/SafeArea.howto.md`
+
+Fetch the how-to:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/walkthroughs/SafeArea.howto.md")
+```
+
+### Step 2: For Detailed Properties Reference
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/SafeArea.md")
+```
+
+## Key Principles (Stable)
+
+- **ALWAYS use SafeArea** on pages with TextBox/PasswordBox on mobile — keyboard WILL obscure inputs otherwise
+- Two usage modes: `<SafeArea Insets="...">` (control) or `utu:SafeArea.Insets="..."` (attached property)
+- `Insets` values: `Left`, `Top`, `Right`, `Bottom`, `SoftInput` (keyboard), or combinations
+- `Mode` — `Padding` (default, adds padding) or `InsetMode.Margin` (adds margin)
+- For keyboard: use `Insets="SoftInput"` or `Insets="SoftInput,Bottom"`
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-input-extensions]] — Auto-focus and keyboard behavior for forms
+- [[uno-toolkit-statusbar-extensions]] — Status bar customization

--- a/skills/uno-toolkit-segmented-controls/SKILL.md
+++ b/skills/uno-toolkit-segmented-controls/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: uno-toolkit-segmented-controls
+description: "Segmented button groups implemented as a `TabBar` with the segmented style."
+when_to_use: "Use when offering 2–5 mutually exclusive inline options (filter modes, view switchers) — the segmented button pattern."
+metadata:
+  author: uno-platform
+  version: "2.6"
+  category: toolkit
+---
+
+# Uno Toolkit Segmented Controls — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the Segmented Control Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit segmented control TabBar button group exclusive")
+```
+
+Primary documentation pages:
+- **TabBar & TabBarItem** (segmented section): `external/uno.toolkit.ui/doc/controls/TabBarAndTabBarItem.md`
+
+Fetch the TabBar page and look for segmented control styles:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/TabBarAndTabBarItem.md")
+```
+
+## Critical Rules
+
+- The segmented style key is **`SegmentedStyle`** — apply it on the `TabBar` (`Style="{StaticResource SegmentedStyle}"`). There is no `SegmentedTabBarStyle` key; using that name will silently fall through to the default `TabBar` look.
+
+## Key Principles (Stable)
+
+- Segmented controls use `TabBar` with `Style="{StaticResource SegmentedStyle}"`
+- Each option is a `TabBarItem`
+- Single selection mode — mutually exclusive options
+- The concrete segmented-button visual comes from the active design-theme
+
+## Related Skills
+
+- [[uno-toolkit-tabbar]] — Full TabBar reference
+- [[uno-toolkit-chip]] — Alternative selection via ChipGroup

--- a/skills/uno-toolkit-selector-extensions/SKILL.md
+++ b/skills/uno-toolkit-selector-extensions/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: uno-toolkit-selector-extensions
+description: "Use SelectorExtensions to sync a Selector control (FlipView, ListView) with a PipsPager. The PipsPager attached property auto-syncs NumberOfPages and SelectedIndex."
+when_to_use: "Use when synchronising a `PipsPager` indicator with a `FlipView` or `ListView` selection — carousel and slideshow UIs. The attached property auto-syncs `NumberOfPages` and `SelectedIndex` between the two controls."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit Selector Extensions — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the SelectorExtensions Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit SelectorExtensions PipsPager Selector sync FlipView")
+```
+
+Primary documentation page:
+- **Selector Extensions**: `external/uno.toolkit.ui/doc/helpers/Selector-extensions.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/helpers/Selector-extensions.md")
+```
+
+## Key Principles (Stable)
+
+- Only one attached property: `utu:SelectorExtensions.PipsPager`
+- The property must be set on the **Selector control** (FlipView, ListView), **NOT** on the PipsPager
+- Automatically syncs `NumberOfPages` and `SelectedIndex` bidirectionally
+- Swiping the Selector updates the pip; clicking a pip navigates the Selector
+- Do not manually set `NumberOfPages` on the PipsPager — it is auto-managed
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-flipview-extensions]] — Previous/Next buttons for FlipView
+- [[uno-toolkit-itemsrepeater-extensions]] — Selection for ItemsRepeater

--- a/skills/uno-toolkit-shadowcontainer/SKILL.md
+++ b/skills/uno-toolkit-shadowcontainer/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: uno-toolkit-shadowcontainer
+description: "Use ShadowContainer to add multiple layered shadows to controls. Supports both drop shadows and inner (inset) shadows."
+when_to_use: "Use when `ThemeShadow` is insufficient — multiple stacked shadows, inset shadows, or precise per-shadow colors. Each shadow exposes offset, blur, spread, color, and opacity."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit ShadowContainer — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the ShadowContainer Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit ShadowContainer shadow drop inner inset layer")
+```
+
+Primary documentation page:
+- **ShadowContainer**: `external/uno.toolkit.ui/doc/controls/ShadowContainer.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/ShadowContainer.md")
+```
+
+### Step 2: For How-To / Walkthrough
+
+```
+uno_platform_docs_search("ShadowContainer howto walkthrough shadow example")
+```
+
+## Key Principles (Stable)
+
+- Shadow properties work like CSS `box-shadow` — the API is a 1-to-1 mapping
+- `ShadowCollection` property contains a collection of `Shadow` items
+- Each `Shadow` has: `OffsetX`, `OffsetY`, `BlurRadius`, `SpreadRadius`, `Color`, `Opacity`
+- `IsInner="True"` creates an inset shadow
+- **Background must be set on ShadowContainer, not on the child** for inner shadows to work
+- Multiple shadows layer on top of each other for complex effects
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-card]] — Cards with built-in elevation
+- [[uno-themes-material]] — Material elevation extension

--- a/skills/uno-toolkit-statusbar-extensions/SKILL.md
+++ b/skills/uno-toolkit-statusbar-extensions/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: uno-toolkit-statusbar-extensions
+description: "Attached properties (`StatusBar.Foreground`, `StatusBar.Background`) for customising the system status bar from XAML on mobile platforms."
+when_to_use: "Use when customising the system status bar on iOS or Android — light vs dark icons, background tint, or visibility — per page from XAML."
+metadata:
+  author: uno-platform
+  version: "2.5"
+  category: toolkit
+---
+
+# Uno Toolkit StatusBar Extensions — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the StatusBar Extensions Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit StatusBar extensions foreground background color iOS Android")
+```
+
+Primary documentation page:
+- **StatusBar Extensions**: `external/uno.toolkit.ui/doc/helpers/StatusBar-extensions.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/helpers/StatusBar-extensions.md")
+```
+
+## Critical Rules
+
+- **`StatusBar.Foreground` is a `StatusBarForegroundTheme` enum value, NOT a Brush.** Use attribute syntax with a bare enum name: `utu:StatusBar.Foreground="Light"` (or `Dark`, `Auto`, `AutoInverse`). Element syntax or a Brush value (e.g. `<utu:StatusBar.Foreground><SolidColorBrush Color="White"/></utu:StatusBar.Foreground>`) is **invalid**.
+- `StatusBar.Background` *is* a color/brush — accepts an attribute color name or a `{StaticResource}` brush.
+- The class is **`StatusBar`**, not `StatusBarExtensions`, despite the file/skill name.
+
+## Key Principles (Stable)
+
+- `utu:StatusBar.Foreground` — StatusBarForegroundTheme enum value
+- `utu:StatusBar.Background` — color or brush
+- StatusBarForegroundTheme values: `Light` (white icons), `Dark` (black icons), `Auto` (matches theme, updates on change), `AutoInverse` (opposite of theme, updates on change)
+- Applied as attached properties on the Page element
+- Works on iOS and Android only
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-safearea]] — Safe area insets for status bar

--- a/skills/uno-toolkit-system-theme-helper/SKILL.md
+++ b/skills/uno-toolkit-system-theme-helper/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: uno-toolkit-system-theme-helper
+description: "Use SystemThemeHelper to detect system theme (light/dark), check if dark mode is active, and set application theme. Provides static methods for theme retrieval and management."
+when_to_use: "Use when reading or programmatically switching dark / light mode from C# (not the XAML `ThemeResource` lookup path) — detecting the current system theme, setting the application theme at runtime, or toggling between modes."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit SystemThemeHelper — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the SystemThemeHelper Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit SystemThemeHelper theme light dark mode detect")
+```
+
+Primary documentation page:
+- **SystemThemeHelper**: `external/uno.toolkit.ui/doc/helpers/SystemThemeHelper.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/helpers/SystemThemeHelper.md")
+```
+
+## Key Principles (Stable)
+
+- `SystemThemeHelper.GetCurrentOsTheme()` — returns `ApplicationTheme.Light` or `ApplicationTheme.Dark`
+- `SystemThemeHelper.GetRootTheme(XamlRoot?)` — gets the app theme for a given XamlRoot
+- `SystemThemeHelper.IsRootInDarkMode(XamlRoot?)` — quick check if dark mode is active
+- `SystemThemeHelper.SetRootTheme(XamlRoot?, bool)` — set theme (`true` = dark)
+- `SystemThemeHelper.SetApplicationTheme(XamlRoot?, ElementTheme)` — set theme using ElementTheme enum
+- **No `ThemeChanged` event exists** — there is no event to subscribe to for theme changes
+- Namespace: `using Uno.Toolkit.UI;`
+
+## Related Skills
+
+- [[uno-themes-semantic-colors-brushes]] — Semantic color palette and brush system

--- a/skills/uno-toolkit-tabbar/SKILL.md
+++ b/skills/uno-toolkit-tabbar/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: uno-toolkit-tabbar
+description: "Use TabBar and TabBarItem for tab navigation with icons, labels, badges, and selection indicators. Supports bottom navigation, top tabs, and vertical tabs."
+when_to_use: "Use when styling a `TabBar`'s visual appearance (icons, labels, badges, selection indicator, bottom / top / vertical orientation). For region wiring inside a navigation shell, use `uno-navigation-tabbar` instead. Always set an explicit `Style` for proper appearance."
+metadata:
+  author: uno-platform
+  version: "2.5"
+  category: toolkit
+---
+
+# Uno Toolkit TabBar — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the TabBar Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit TabBar TabBarItem bottom navigation styles icons badges")
+```
+
+Primary documentation page:
+- **TabBar & TabBarItem**: `external/uno.toolkit.ui/doc/controls/TabBarAndTabBarItem.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/TabBarAndTabBarItem.md")
+```
+
+### Step 2: For TabBar with Navigation Extensions
+
+If using TabBar as a navigation control:
+
+See the `uno-navigation-tabbar` skill for region-based navigation integration.
+
+### Step 3: For Chefs TabBar Example
+
+```
+uno_platform_docs_search("Chefs TabBar navigate bottom tab example")
+```
+
+Key page:
+- **Chefs Navigate TabBar**: `external/uno.chefs/doc/toolkit/NavigateTabBar.md`
+
+## Key Principles (Stable)
+
+- **Always apply a style** to TabBar for proper appearance (e.g., `BottomTabBarStyle`, `TopTabBarStyle`, `VerticalTabBarStyle`)
+- Styling goes on the **TabBar container**, not individual TabBarItems
+- `TabBarItem` supports `Icon`, `Content` (label), and `Badge`
+- For navigation, use with `uen:Region.Name` on each TabBarItem
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-navigation-tabbar]] — TabBar with Navigation Extensions
+- [[uno-toolkit-tabbaritem-extensions]] — TabBarItem attached properties
+- [[uno-toolkit-segmented-controls]] — Segmented control style

--- a/skills/uno-toolkit-tabbaritem-extensions/SKILL.md
+++ b/skills/uno-toolkit-tabbaritem-extensions/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: uno-toolkit-tabbaritem-extensions
+description: "Use TabBarItemExtensions to configure TabBarItem on-click navigation behavior."
+when_to_use: "Use when a `TabBarItem` must trigger navigation directly on click — the attached properties wire the tap into a navigation request without a code-behind handler."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit TabBarItem Extensions — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the TabBarItem Extensions Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit TabBarItem extensions command badge selection indicator")
+```
+
+Primary documentation page:
+- **TabBarItem Extensions**: `external/uno.toolkit.ui/doc/helpers/TabBarItem-extensions.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/helpers/TabBarItem-extensions.md")
+```
+
+## Key Principles (Stable)
+
+- Attached properties for `TabBarItem` controls
+- Enables on-click navigation behavior
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-tabbar]] — TabBar control reference
+- [[uno-toolkit-command-extensions]] — General command extensions

--- a/skills/uno-toolkit-visualstatemanager-extensions/SKILL.md
+++ b/skills/uno-toolkit-visualstatemanager-extensions/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: uno-toolkit-visualstatemanager-extensions
+description: "Use VisualStateManagerExtensions to create data-driven visual states. Bind VisualState directly to view model properties."
+when_to_use: "Use when visual states must be driven by view-model properties rather than `VisualStateManager.GoToState` calls from code-behind — bind the active state name (e.g. an enum) and the framework swaps states automatically."
+metadata:
+  author: uno-platform
+  version: "2.4"
+  category: toolkit
+---
+
+# Uno Toolkit VisualStateManager Extensions — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the VisualStateManager Extensions Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit VisualStateManager extensions data driven visual state binding")
+```
+
+Primary documentation page:
+- **VisualStateManager Extensions**: `external/uno.toolkit.ui/doc/helpers/VisualStateManager-extensions.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/helpers/VisualStateManager-extensions.md")
+```
+
+## Key Principles (Stable)
+
+- `utu:VisualStateManagerExtensions.States` — attached property bound to a string property (note: **States** plural)
+- Supports comma, semicolon, or space separated list for multiple concurrent states from different VisualStateGroups
+- When the bound property changes, the matching VisualState is activated
+- Property value maps directly to VisualState name
+- Eliminates need for code-behind `VisualStateManager.GoToState()` calls
+- **Important**: `VisualStateManager.VisualStateGroups` must be defined on the same element that has the `States` attached property
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- [[uno-toolkit-responsive]] — Responsive layout based on screen size

--- a/skills/uno-toolkit-zoomcontentcontrol/SKILL.md
+++ b/skills/uno-toolkit-zoomcontentcontrol/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: uno-toolkit-zoomcontentcontrol
+description: "Zoomable and pannable container for images, maps, diagrams, or document viewers."
+when_to_use: "Use when zoom and pan are needed for images, maps, diagrams, or document viewers — mouse wheel zoom, middle-click pan, pinch-to-zoom, configurable min/max zoom levels, and programmatic control."
+metadata:
+  author: uno-platform
+  version: "2.5"
+  category: toolkit
+---
+
+# Uno Toolkit ZoomContentControl — Agent Skill
+
+## Workflow
+
+> **Docs lookup:** call `uno_platform_docs_search(...)` first, then `uno_platform_docs_fetch(sourcePath="…")` using the `sourcePath` field from a result (a relative `.md` path; add the result's `anchor` for a section). Never pass a URL, a `.html` link, or a hand-built path.
+
+### Step 1: Fetch the ZoomContentControl Documentation
+
+```
+uno_platform_docs_search("Uno Toolkit ZoomContentControl zoom pan pinch mouse wheel")
+```
+
+Primary documentation page:
+- **ZoomContentControl**: `external/uno.toolkit.ui/doc/controls/ZoomContentControl.md`
+
+Fetch the page:
+
+```
+uno_platform_docs_fetch(sourcePath="external/uno.toolkit.ui/doc/controls/ZoomContentControl.md")
+```
+
+## Critical Rules
+
+- The fit-to-available-size property is **`AutoFit`** (boolean). There is **no `AutoFitToCanvas`** property — that name does not exist on `ZoomContentControl`.
+- Programmatic zoom uses methods `ZoomTo(float)` and `ZoomToRect(Rect)` on the control instance — not a settable `Zoom` property.
+
+## Key Principles (Stable)
+
+- `MinZoomLevel` and `MaxZoomLevel` — zoom range
+- `ZoomLevel` — current zoom (bindable, two-way)
+- `IsZoomAllowed` — enable/disable zoom
+- `IsPanAllowed` — enable/disable pan
+- `AutoFit` — fit content to available size
+- Supports mouse wheel, middle-click pan, pinch-to-zoom gestures
+- XAML namespace: `xmlns:utu="using:Uno.Toolkit.UI"`
+
+## Related Skills
+
+- (standalone control, no primary dependencies)


### PR DESCRIPTION
This PR ships the first Uno Platform plugin for AI coding agents:

- **`plugins/uno-platform-studio/`**: the installable plugin bundling skills covering MVUX, navigation, Uno Toolkit, theming (Material, Simple, shared semantic), and UI testing, with native manifests for Claude Code, GitHub Copilot CLI, Copilot in VS Code, and OpenAI Codex CLI.
- **Three marketplace manifests** making this repository installable as a plugin source:
  - `.claude-plugin/marketplace.json` (Claude Code)
  - `.github/plugin/marketplace.json` (GitHub Copilot)
  - `.agents/plugins/marketplace.json` (Codex CLI)
- **`skills/`**: standalone copies of the same skills at the repository root, for agents without plugin support (Cursor, Gemini CLI, Windsurf, Cline, and others).

## Try it from this branch

To review the plugin without merging, add the marketplace directly from this branch in Claude Code:

```text
/plugin marketplace add unoplatform/studio@dev/ak/studio-plugin
/plugin install uno-platform-studio@uno-platform
```

If prompted, run `/reload-plugins`, then verify with `/skills`. To clean up afterwards:

```text
/plugin uninstall uno-platform-studio@uno-platform
/plugin marketplace remove uno-platform
```

## Install (once merged)

```text
/plugin marketplace add unoplatform/studio
/plugin install uno-platform-studio@uno-platform
```

Equivalent commands exist for Copilot CLI and Codex CLI; agents without plugin support copy folders from `skills/`. Full instructions are in the plugin README and `skills/README.md`.
