### PR TITLE
ci: map Studio 3.0 tools to labels in add-tools-labels

### DIFF
--- a/.github/workflows/add-tools-labels.yml
+++ b/.github/workflows/add-tools-labels.yml
@@ -27,17 +27,24 @@ jobs:
             const tools = toolsRaw.split(',').map(tool => tool.trim()).filter(tool => tool !== "_No response_");
             console.log("Parsed Tools:", tools);
 
-            // Define labels to add based on the selected tools
-            const labelsToAdd = [];
-            if (tools.includes("Hot Design®") || tools.includes("Hot Design")) {
-              labelsToAdd.push("tool/Hot Design®");
-            }
-            if (tools.includes("Hot Reload")) {
-              labelsToAdd.push("tool/Hot Reload");
-            }
-            if (tools.includes("Design-to-Code")) {
-              labelsToAdd.push("tool/Design-to-Code");
-            }
+            // Map each "Which tool(s) are affected?" dropdown option to its tool/* label.
+            // Keep this in sync with the dropdown options in the issue templates.
+            const toolLabelMap = {
+              "Uno Platform Studio App": "tool/Uno Platform Studio App",
+              "Uno Platform Studio Agent": "tool/Uno Platform Studio Agent",
+              "Uno Platform Skills": "tool/Uno Platform Skills",
+              "Hot Design®": "tool/Hot Design®",
+              "Hot Design": "tool/Hot Design®", // tolerate a stripped ®
+              "Hot Design® Agent": "tool/Hot Design® Agent",
+              "Uno MCPs": "tool/Uno MCPs",
+              "Hot Reload": "tool/Hot Reload",
+              "Design-to-Code": "tool/Design-to-Code",
+            };
+
+            // Resolve selected tools to labels, dropping unknowns and de-duplicating.
+            const labelsToAdd = [...new Set(
+              tools.map(tool => toolLabelMap[tool]).filter(Boolean)
+            )];
 
             // Add the labels to the issue if any were matched
             if (labelsToAdd.length > 0) {


### PR DESCRIPTION
GitHub Issue (If applicable): tracked internally

<!-- Link to the relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub or internal). -->

## PR Type

What kind of change does this PR introduce?

- [x] Build or CI related changes
- [x] Project automation

## What is the current behavior?

`add-tools-labels.yml` auto-applies a `tool/*` label from the "Which tool(s) are affected?" dropdown, but only handles three of the dropdown's options (`Hot Design®`, `Hot Reload`, `Design-to-Code`). It never labels the existing `Hot Design® Agent` or `Uno MCPs` selections, and has no mapping for the newer Uno Platform Studio surfaces.

## What is the new behavior?

The label step now maps **every** dropdown option to its `tool/*` label via a single declarative map that is meant to stay in sync with the issue templates:

- Adds the new **Uno Platform Studio App**, **Uno Platform Studio Agent**, and **Uno Platform Skills** surfaces.
- Adds the previously-unhandled **Hot Design® Agent** and **Uno MCPs** options.
- Keeps **Hot Design®**, **Hot Reload**, and **Design-to-Code**, plus a tolerant alias for a stripped `®`.
- De-duplicates resolved labels and ignores unknown values.

The five matching `tool/*` labels (`tool/Uno Platform Studio App`, `tool/Uno Platform Studio Agent`, `tool/Uno Platform Skills`, `tool/Hot Design® Agent`, `tool/Uno MCPs`) were created in the repository with the same color (`#A6278C`) as the existing `tool/*` labels.

Validated by replaying the script's parsing/matching logic against representative issue bodies (single/multi-select, `_No response_`, the `Hot Design®` vs `Hot Design® Agent` disambiguation, the legacy stripped-`®` alias, and unknown values).

## PR Checklist

- [x] Documentation has been added/updated
- [x] Associated with an issue (GitHub or internal)

## Additional Information

Companion to the issue-template refresh in #135, which introduces the matching dropdown options this workflow reads.
